### PR TITLE
Vulkan fixup

### DIFF
--- a/i686/amdvlk-pro-rdna2.i686/amdvlk-pro-rdna2.i686.spec
+++ b/i686/amdvlk-pro-rdna2.i686/amdvlk-pro-rdna2.i686.spec
@@ -105,7 +105,6 @@ Amdgpu Pro Vulkan driver for rdna2
 
 %post 
 /sbin/ldconfig 
-/usr/bin/ln -s /opt/amdgpu-pro/etc/vulkan/icd.d/amd_icd32.json /usr/share/vulkan/icd.d/amd_pro_icd32.json
 
 
 

--- a/i686/amdvlk-pro-rdna2.i686/amdvlk-pro-rdna2.i686.spec
+++ b/i686/amdvlk-pro-rdna2.i686/amdvlk-pro-rdna2.i686.spec
@@ -110,4 +110,4 @@ Amdgpu Pro Vulkan driver for rdna2
 
 %postun 
 /sbin/ldconfig
-rm /usr/share/vulkan/icd.d/amd_pro_icd32.json
+

--- a/i686/amdvlk-pro-rdna2.i686/amdvlk-pro-rdna2.i686.spec
+++ b/i686/amdvlk-pro-rdna2.i686/amdvlk-pro-rdna2.i686.spec
@@ -22,9 +22,6 @@ Provides:      vulkan-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
 Provides:      vulkan-amdgpu-pro(i686) = 0:%{major}-%{minor}.el%{rhel_minor}
 Requires:      vulkan-loader
 
-Requires(post): /sbin/ldconfig  
-Requires(postun): /sbin/ldconfig 
-
 BuildRequires: wget 
 BuildRequires: cpio
 
@@ -102,12 +99,4 @@ Amdgpu Pro Vulkan driver for rdna2
 %exclude "/debs"
 %exclude "/usr/lib/.build-id"
 
-
-%post 
-/sbin/ldconfig 
-
-
-
-%postun 
-/sbin/ldconfig
 

--- a/i686/amdvlk-pro.i686/amdvlk-pro.i686.spec
+++ b/i686/amdvlk-pro.i686/amdvlk-pro.i686.spec
@@ -110,4 +110,4 @@ Amdgpu Pro Vulkan driver
 
 %postun 
 /sbin/ldconfig
-rm /usr/share/vulkan/icd.d/amd_pro_icd32.json
+

--- a/i686/amdvlk-pro.i686/amdvlk-pro.i686.spec
+++ b/i686/amdvlk-pro.i686/amdvlk-pro.i686.spec
@@ -107,7 +107,6 @@ Amdgpu Pro Vulkan driver
 
 %post 
 /sbin/ldconfig 
-/usr/bin/ln -s /opt/amdgpu-pro/etc/vulkan/icd.d/amd_icd32.json /usr/share/vulkan/icd.d/amd_pro_icd32.json
 
 %postun 
 /sbin/ldconfig

--- a/i686/amdvlk-pro.i686/amdvlk-pro.i686.spec
+++ b/i686/amdvlk-pro.i686/amdvlk-pro.i686.spec
@@ -27,9 +27,6 @@ Requires:      vulkan-loader
 BuildRequires: wget 
 BuildRequires: cpio
 
-Requires(post): /sbin/ldconfig  
-Requires(postun): /sbin/ldconfig 
-
 Recommends:	 openssl-libs  
 
 
@@ -105,9 +102,4 @@ Amdgpu Pro Vulkan driver
 %exclude "/debs"
 %exclude "/usr/lib/.build-id"
 
-%post 
-/sbin/ldconfig 
-
-%postun 
-/sbin/ldconfig
 

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -25,6 +25,11 @@ Provides:      config(amdvlk) = %{amdvlk}-3
 Requires:      config(amdvlk) = %{amdvlk}-3
 Requires:      vulkan-loader
 
+BuildRequires: wget 
+BuildRequires: cpio
+
+Recommends:	 openssl-libs  
+
 %build
 
 echo "pulling required packages off repo.radeon.com"
@@ -59,7 +64,9 @@ echo "restructuring package directories  "
 
 cd %{buildroot}/debs/extract
 
-mv ./usr/lib/i386-linux-gnu/* ./usr/lib/
+mkdir -p ./opt/amdgpu/vulkan
+
+mv ./usr/lib/i386-linux-gnu/* ./opt/amdgpu/vulkan/lib32
 
 rm -r ./usr/lib/i386-linux-gnu
 
@@ -69,19 +76,19 @@ rm -r ./usr/share
 
 echo "fixing .icds "
 
-sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/usr/lib/amdvlk32.so#" "./etc/vulkan/icd.d/amd_icd32.json"
+sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu-pro/vulkan/lib32/amdvlk32.so#" "./etc/vulkan/icd.d/amd_icd32.json"
 
-sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/usr/lib/amdvlk32.so#" "./etc/vulkan/implicit_layer.d/amd_icd32.json"
+# we don't need this one
+rm ./etc/vulkan/implicit_layer.d/amd_icd32.json"
 
 ###
 
-mv ./usr %{buildroot}/
+mv ./opt %{buildroot}/
 mv ./etc %{buildroot}/
 
 %files
-"/etc/vulkan/icd.d/amd_icd32.json"
-"/etc/vulkan/implicit_layer.d/amd_icd32.json"
-"/usr/lib/amdvlk32.so"
+"/opt/amdgpu/etc/vulkan/icd.d/amd_icd32.json"
+"/opt/amdgpu/vulkan/lib32/amdvlk32.so"
 %exclude "/debs"
 %exclude "/usr/lib/.build-id"
 

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -79,7 +79,7 @@ echo "fixing .icds "
 sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu-pro/vulkan/lib32/amdvlk32.so#" "./etc/vulkan/icd.d/amd_icd32.json"
 
 # we don't need this one
-rm ./etc/vulkan/implicit_layer.d/amd_icd32.json"
+rm ./etc/vulkan/implicit_layer.d/amd_icd32.json
 
 ###
 

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -90,7 +90,6 @@ AMD Open Source Driver for Vulkan
 
 %post 
 /sbin/ldconfig 
-/usr/bin/ln -s /etc/vulkan/icd.d/amd_icd32.json /usr/share/vulkan/icd.d/amd_icd32.json
 
 %postun 
 /sbin/ldconfig

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -74,7 +74,7 @@ rm -r ./usr/share
 
 echo "fixing .icds "
 
-sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu-pro/vulkan/lib32/amdvlk32.so#" "./etc/vulkan/icd.d/amd_icd32.json"
+sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu/vulkan/lib32/amdvlk32.so#" "./etc/vulkan/icd.d/amd_icd32.json"
 
 # we don't need this one
 rm ./etc/vulkan/implicit_layer.d/amd_icd32.json

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -93,4 +93,4 @@ AMD Open Source Driver for Vulkan
 
 %postun 
 /sbin/ldconfig
-rm /usr/share/vulkan/icd.d/amd_icd32.json
+

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -66,9 +66,7 @@ cd %{buildroot}/debs/extract
 
 mkdir -p ./opt/amdgpu/vulkan
 
-mv ./usr/lib/i386-linux-gnu/* ./opt/amdgpu/vulkan/lib32
-
-rm -r ./usr/lib/i386-linux-gnu
+mv ./usr/lib/i386-linux-gnu ./opt/amdgpu/vulkan/lib32
 
 rm -r ./usr/share
 
@@ -84,7 +82,7 @@ rm ./etc/vulkan/implicit_layer.d/amd_icd32.json
 ###
 
 mv ./opt %{buildroot}/
-mv ./etc %{buildroot}/
+mv ./etc %{buildroot}/opt/amdgpu/
 
 %files
 "/opt/amdgpu/etc/vulkan/icd.d/amd_icd32.json"

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -88,9 +88,4 @@ mv ./etc %{buildroot}/
 %description
 AMD Open Source Driver for Vulkan
 
-%post 
-/sbin/ldconfig 
-
-%postun 
-/sbin/ldconfig
 

--- a/x86_64/amdvlk-pro-rdna2/amdvlk-pro-rdna2.spec
+++ b/x86_64/amdvlk-pro-rdna2/amdvlk-pro-rdna2.spec
@@ -103,7 +103,6 @@ Amdgpu Pro Vulkan driver for RDNA2
 
 %post 
 /sbin/ldconfig 
-/usr/bin/ln -s /opt/amdgpu-pro/etc/vulkan/icd.d/amd_icd64.json /usr/share/vulkan/icd.d/amd_pro_icd64.json
 
 
 

--- a/x86_64/amdvlk-pro-rdna2/amdvlk-pro-rdna2.spec
+++ b/x86_64/amdvlk-pro-rdna2/amdvlk-pro-rdna2.spec
@@ -108,4 +108,4 @@ Amdgpu Pro Vulkan driver for RDNA2
 
 %postun 
 /sbin/ldconfig
-rm /usr/share/vulkan/icd.d/amd_pro_icd64.json
+

--- a/x86_64/amdvlk-pro-rdna2/amdvlk-pro-rdna2.spec
+++ b/x86_64/amdvlk-pro-rdna2/amdvlk-pro-rdna2.spec
@@ -23,9 +23,6 @@ Provides:      vulkan-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
 Provides:      vulkan-amdgpu-pro(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
 Requires:      vulkan-loader
 
-Requires(post): /sbin/ldconfig  
-Requires(postun): /sbin/ldconfig 
-
 Recommends:	 openssl-libs  
 Recommends:	 amdgpu-vulkan-switcher
 
@@ -101,11 +98,4 @@ Amdgpu Pro Vulkan driver for RDNA2
 %exclude "/rpms"
 %exclude "/usr/lib/.build-id"
 
-%post 
-/sbin/ldconfig 
-
-
-
-%postun 
-/sbin/ldconfig
 

--- a/x86_64/amdvlk-pro/amdvlk-pro.spec
+++ b/x86_64/amdvlk-pro/amdvlk-pro.spec
@@ -24,9 +24,6 @@ Provides:      vulkan-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
 Provides:      vulkan-amdgpu-pro(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
 Requires:      vulkan-loader
 
-Requires(post): /sbin/ldconfig  
-Requires(postun): /sbin/ldconfig 
-
 Recommends:	 openssl-libs  
 Recommends:	 amdgpu-vulkan-switcher
 
@@ -109,4 +106,4 @@ Amdgpu Pro Vulkan driver
 
 %postun 
 /sbin/ldconfig
-rm /usr/share/vulkan/icd.d/amd_pro_icd64.json
+

--- a/x86_64/amdvlk-pro/amdvlk-pro.spec
+++ b/x86_64/amdvlk-pro/amdvlk-pro.spec
@@ -104,7 +104,6 @@ Amdgpu Pro Vulkan driver
 
 %post 
 /sbin/ldconfig 
-/usr/bin/ln -s /opt/amdgpu-pro/etc/vulkan/icd.d/amd_icd64.json /usr/share/vulkan/icd.d/amd_pro_icd64.json
 
 
 

--- a/x86_64/amdvlk-pro/amdvlk-pro.spec
+++ b/x86_64/amdvlk-pro/amdvlk-pro.spec
@@ -99,11 +99,4 @@ Amdgpu Pro Vulkan driver
 %exclude "/rpms"
 %exclude "/usr/lib/.build-id"
 
-%post 
-/sbin/ldconfig 
-
-
-
-%postun 
-/sbin/ldconfig
 

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -66,9 +66,7 @@ cd %{buildroot}/debs/extract
 
 mkdir -p ./opt/amdgpu/vulkan
 
-mv ./usr/lib/x86_64-linux-gnu/* ./opt/amdgpu/vulkan/lib64
-
-rm -r ./usr/lib/x86_64-linux-gnu
+mv ./usr/lib/x86_64-linux-gnu ./opt/amdgpu/vulkan/lib64
 
 rm -r ./usr/share
 
@@ -84,7 +82,7 @@ rm ./etc/vulkan/implicit_layer.d/amd_icd64.json
 ###
 
 mv ./opt %{buildroot}/
-mv ./etc %{buildroot}/
+mv ./etc %{buildroot}/opt/amdgpu/
 
 %files
 "/opt/amdgpu/etc/vulkan/icd.d/amd_icd64.json"

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -38,7 +38,7 @@ mkdir -p %{buildroot}/debs
 
 cd %{buildroot}/debs
 
-wget http://repo.radeon.com/amdvlk/apt/debian/pool/main/a/amdvlk/amdvlk_"%{amdvlk}"_x86_64.deb
+wget http://repo.radeon.com/amdvlk/apt/debian/pool/main/a/amdvlk/amdvlk_"%{amdvlk}"_amd64.deb
 
 ###
 
@@ -48,7 +48,7 @@ mkdir -p %{buildroot}/debs/extract
 
 cd %{buildroot}/debs/extract
 
-ar -x ../amdvlk_"%{amdvlk}"_x86_64.deb
+ar -x ../amdvlk_"%{amdvlk}"_amd64.deb
 
 tar -xf data.tar.gz
 

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -66,9 +66,9 @@ cd %{buildroot}/debs/extract
 
 mkdir -p ./opt/amdgpu/vulkan
 
-mv ./usr/lib/_x86_64-linux-gnu/* ./opt/amdgpu/vulkan/lib64
+mv ./usr/lib/x86_64-linux-gnu/* ./opt/amdgpu/vulkan/lib64
 
-rm -r ./usr/lib/_x86_64-linux-gnu
+rm -r ./usr/lib/x86_64-linux-gnu
 
 rm -r ./usr/share
 
@@ -76,7 +76,7 @@ rm -r ./usr/share
 
 echo "fixing .icds "
 
-sed -i "s#/usr/lib/_x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu-pro/vulkan/lib64/amdvlk64.so#" "./etc/vulkan/icd.d/amd_icd64.json"
+sed -i "s#/usr/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu-pro/vulkan/lib64/amdvlk64.so#" "./etc/vulkan/icd.d/amd_icd64.json"
 
 # we don't need this one
 rm ./etc/vulkan/implicit_layer.d/amd_icd64.json"

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -79,7 +79,7 @@ echo "fixing .icds "
 sed -i "s#/usr/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu-pro/vulkan/lib64/amdvlk64.so#" "./etc/vulkan/icd.d/amd_icd64.json"
 
 # we don't need this one
-rm ./etc/vulkan/implicit_layer.d/amd_icd64.json"
+rm ./etc/vulkan/implicit_layer.d/amd_icd64.json
 
 ###
 

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -1,0 +1,98 @@
+%global amdpro 22.20.1
+%global major 22.20
+%global minor 1447095
+%global amf 1.4.26
+%global enc 1.0
+%global rhel_major 9.0
+%global rhel_minor 9
+%global amdvlk 2022.Q3.1
+%global fedora fc36
+%global ubuntu 22.04
+
+Name:          amdvlk
+Version:       %{amdvlk}
+Release:       3
+License:       MIT 
+Group:         System Environment/Libraries
+Summary:       AMD Open Source Driver for Vulkan
+
+URL:           https://github.com/GPUOpen-Drivers/AMDVLK
+Vendor:        Advanced Micro Devices (AMD)
+
+Provides:      amdvlk = %{amdvlk}-3
+Provides:      amdvlk(x86_64) = %{amdvlk}-3
+Provides:      config(amdvlk) = %{amdvlk}-3
+Requires:      config(amdvlk) = %{amdvlk}-3
+Requires:      vulkan-loader
+
+BuildRequires: wget 
+BuildRequires: cpio
+
+Recommends:	 openssl-libs  
+
+%build
+
+echo "pulling required packages off repo.radeon.com"
+
+mkdir -p %{buildroot}/debs
+
+cd %{buildroot}/debs
+
+wget http://repo.radeon.com/amdvlk/apt/debian/pool/main/a/amdvlk/amdvlk_"%{amdvlk}"_x86_64.deb
+
+###
+
+echo "extracting packages"
+
+mkdir -p %{buildroot}/debs/extract
+
+cd %{buildroot}/debs/extract
+
+ar -x ../amdvlk_"%{amdvlk}"_x86_64.deb
+
+tar -xf data.tar.gz
+
+rm -r *.tar*
+
+rm debian-binary
+
+###
+
+#
+
+echo "restructuring package directories  "
+
+cd %{buildroot}/debs/extract
+
+mkdir -p ./opt/amdgpu/vulkan
+
+mv ./usr/lib/_x86_64-linux-gnu/* ./opt/amdgpu/vulkan/lib64
+
+rm -r ./usr/lib/_x86_64-linux-gnu
+
+rm -r ./usr/share
+
+#
+
+echo "fixing .icds "
+
+sed -i "s#/usr/lib/_x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu-pro/vulkan/lib64/amdvlk64.so#" "./etc/vulkan/icd.d/amd_icd64.json"
+
+# we don't need this one
+rm ./etc/vulkan/implicit_layer.d/amd_icd64.json"
+
+###
+
+mv ./opt %{buildroot}/
+mv ./etc %{buildroot}/
+
+%files
+"/opt/amdgpu/etc/vulkan/icd.d/amd_icd64.json"
+"/opt/amdgpu/vulkan/lib64/amdvlk64.so"
+%exclude "/debs"
+%exclude "/usr/lib/.build-id"
+
+%description
+AMD Open Source Driver for Vulkan
+
+

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -74,7 +74,7 @@ rm -r ./usr/share
 
 echo "fixing .icds "
 
-sed -i "s#/usr/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu-pro/vulkan/lib64/amdvlk64.so#" "./etc/vulkan/icd.d/amd_icd64.json"
+sed -i "s#/usr/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu/vulkan/lib64/amdvlk64.so#" "./etc/vulkan/icd.d/amd_icd64.json"
 
 # we don't need this one
 rm ./etc/vulkan/implicit_layer.d/amd_icd64.json


### PR DESCRIPTION
Several fixups for the vulkan spec sheets, most importantly allows vk_radv to remain the default driver used without needing a launch option.