### PR TITLE
merge Test7 into main.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ amdocl-legacy
 amdogl-pro
 amdvlk
 amdvlk-pro
-amdvlk-pro-rdna2
+amdvlk-pro-legacy
 -------------------------------------
 32 bit package names are:
 libdrm-pro
@@ -61,7 +61,7 @@ amdocl-legacy
 amdogl-pro
 amdvlk
 amdvlk-pro
-amdvlk-pro-rdna2
+amdvlk-pro-legacy
 ```
 
 # How to install the packages:

--- a/i686/amdocl-legacy.i686/amdocl-legacy.i686.spec
+++ b/i686/amdocl-legacy.i686/amdocl-legacy.i686.spec
@@ -68,8 +68,8 @@ tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 mkdir -p %{buildroot}/opt/amdgpu-pro/opencl/%{_lib}
 mkdir -p %{buildroot}/etc/OpenCL/vendors/
 #
-install -p -m755 files/etc/OpenCL/vendors/* %{buildroot}/etc/OpenCL/vendors/
-install -p -m755 files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opencl/%{_lib}/
+cp -r files/etc/OpenCL/vendors/* %{buildroot}/etc/OpenCL/vendors/
+cp -r files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opencl/%{_lib}/
 #
 echo "adding *Disabled* library path"
 mkdir -p %{buildroot}/etc/ld.so.conf.d

--- a/i686/amdocl-legacy.i686/amdocl-legacy.i686.spec
+++ b/i686/amdocl-legacy.i686/amdocl-legacy.i686.spec
@@ -1,125 +1,86 @@
-%undefine _auto_set_build_flags
-%global amdpro 22.20.3
+%define _build_id_links none
+
+# global info
+%global repo 22.20.3
 %global major 22.20
 %global minor 1462318
+# pkg info
 %global amf 1.4.26
 %global enc 1.0
-%global rhel_major 9.0
-%global rhel_minor 9
+#
 %global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global amdgpu 1.0.0.50203
+# Distro info
 %global fedora fc36
 %global ubuntu 22.04
 
-Name:     amdocl-legacy
-Version:       %{amdpro}
-Release:       3.%{fedora}
-License:       AMD GPU PRO EULA 
+
+Name:          amdocl-legacy
+Version:  	   %{repo}
+Release:       4%{?dist}
+License:       AMDGPU PRO  EULA NON-REDISTRIBUTABLE
 Group:         System Environment/Libraries
 Summary:       AMD OpenCL ICD Loaders
-URL:      http://repo.radeon.com/amdgpu
-Provides:      config(opencl-legacy-amdgpu-pro-icd) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      opencl-legacy-amdgpu-pro-icd = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      opencl-legacy-amdgpu-pro-icd(i686) = 0:%{major}-%{minor}.el%{rhel_minor}
+
+URL:           http://repo.radeon.com/amdgpu
+
+%undefine _disable_source_fetch
+Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opencl-legacy-amdgpu-pro/opencl-legacy-amdgpu-pro-icd_%{major}-%{minor}~%{ubuntu}_i386.deb
+Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/ocl-icd-amdgpu-pro/ocl-icd-libopencl1-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_i386.deb
+
+Provides:      amdocl-legacy = %{major}-%{release}
+Provides:      amdocl-legacy(i686) = %{major}-%{release}
+Provides:      config(opencl-legacy-amdgpu-pro-icd) = %{major}-%{minor}~%{ubuntu}
+Provides:      libopencl-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      ocl-icd-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      ocl-icd-amdgpu-pro(i686) = %{major}-%{minor}~%{ubuntu}
+Provides:      opencl-legacy-amdgpu-pro-icd = %{major}-%{minor}~%{ubuntu}
+Provides:      opencl-legacy-amdgpu-pro-icd(i686) = %{major}-%{minor}~%{ubuntu}
 Provides:      opencl-orca-amdgpu-pro-icd  
-Provides:      libopencl-amdgpu-pro = %{major}-%{minor}.el%{rhel_minor}
-Provides:      ocl-icd-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      ocl-icd-amdgpu-pro(i686) = 0:%{major}-%{minor}.el%{rhel_minor}
-
-Requires(post): /sbin/ldconfig  
-Requires(postun): /sbin/ldconfig 
-
-Requires:      libdrm-pro  
 
 BuildRequires: wget 
 BuildRequires: cpio
 
+Requires(post): /sbin/ldconfig  
+Requires(postun): /sbin/ldconfig  
+
+Requires:      libdrm-pro(i686)
+
 Recommends: amdgpu-opencl-switcher(x86_64)
-
-%build
-
-echo "pulling required packages off repo.radeon.com"
-
-mkdir -p %{buildroot}/debs
-
-cd %{buildroot}/debs
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}"/ubuntu/pool/proprietary/o/opencl-legacy-amdgpu-pro/opencl-legacy-amdgpu-pro-icd_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}"/ubuntu/pool/proprietary/o/ocl-icd-amdgpu-pro/ocl-icd-libopencl1-amdgpu-pro_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-###
-
-echo "extracting packages"
-
-mkdir -p %{buildroot}/debs/extract
-
-cd %{buildroot}/debs/extract
-
-ar -x ../opencl-legacy-amdgpu-pro-icd_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-tar -xf data.tar.xz
-
-rm -r *.tar*
-
-rm debian-binary
-
-rm -r ./usr
-
-ar -x ../ocl-icd-libopencl1-amdgpu-pro_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-tar -xf data.tar.xz
-
-rm -r *.tar*
-
-rm debian-binary
-
-rm -r ./usr
-
-###
-
-echo "restructuring package directories  "
-
-cd %{buildroot}/debs/extract
-
-mkdir -p ./opt/amdgpu-pro/OpenCL
-
-mv ./opt/amdgpu-pro/lib/i386-linux-gnu ./opt/amdgpu-pro/OpenCL/lib32
-
-rm -r ./opt/amdgpu-pro/lib
-
-# 
-
-#echo 'patching libs to use official libdrm'
-
-#sed -i "s|libdrm|libdro|g" ./opt/amdgpu-pro/OpenCL/lib32/*.so
-
-# 
-
-echo "adding *Disabled* library path"
-
-mkdir -p ./etc/ld.so.conf.d
-
-touch ./etc/ld.so.conf.d/amdocl-legacy-i686.conf
-
-echo "#/opt/amdgpu-pro/OpenCL/lib32" > ./etc/ld.so.conf.d/amdocl-legacy-i686.conf
-
-###
-
-mv ./opt %{buildroot}/
-mv ./etc %{buildroot}/
 
 %description
 OpenCL (Open Computing Language) is a multivendor open standard for
 general-purpose parallel programming of heterogeneous systems that include
 CPUs, GPUs and other processors. + The ICD Loader library provided by AMD.
 
+%prep
+mkdir -p files
+
+ar x --output . %{SOURCE0}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+ar x --output . %{SOURCE1}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+%install
+mkdir -p %{buildroot}/opt/amdgpu-pro/opencl/%{_lib}
+mkdir -p %{buildroot}/etc/OpenCL/vendors/
+#
+install -p -m755 files/etc/OpenCL/vendors/* %{buildroot}/etc/OpenCL/vendors/
+install -p -m755 files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opencl/%{_lib}/
+#
+echo "adding *Disabled* library path"
+mkdir -p %{buildroot}/etc/ld.so.conf.d
+touch %{buildroot}/etc/ld.so.conf.d/amdocl-legacy-%{_arch}.conf
+echo "#/opt/amdgpu-pro/opencl/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdocl-legacy-%{_arch}.conf
+
 %files
 "/etc/OpenCL/vendors/amdocl-orca32.icd"
-"/etc/ld.so.conf.d/amdocl-legacy-i686.conf"
-"/opt/amdgpu-pro/OpenCL/lib32/libOpenCL.so.1"
-"/opt/amdgpu-pro/OpenCL/lib32/libOpenCL.so.1.2"
-"/opt/amdgpu-pro/OpenCL/lib32/libamdocl-orca32.so"
-%exclude "/debs"
+"/etc/ld.so.conf.d/amdocl-legacy-%{_arch}.conf"
+"/opt/amdgpu-pro/opencl/%{_lib}/libOpenCL*"
+"/opt/amdgpu-pro/opencl/%{_lib}/libamdocl-orca*"
 
 %post
 /sbin/ldconfig

--- a/i686/amdogl-pro.i686/amdogl-pro.i686.spec
+++ b/i686/amdogl-pro.i686/amdogl-pro.i686.spec
@@ -1,246 +1,137 @@
-%undefine _auto_set_build_flags
-%global amdpro 22.20.3
+%define _build_id_links none
+
+# global info
+%global repo 22.20.3
 %global major 22.20
 %global minor 1462318
+# pkg info
 %global amf 1.4.26
 %global enc 1.0
-%global rhel_major 9.0
-%global rhel_minor 9
+#
 %global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global amdgpu 1.0.0.50203
+# Distro info
 %global fedora fc36
 %global ubuntu 22.04
 
 Name:     amdogl-pro
-Version:       %{amdpro}
-Release:       3.%{fedora}
-License:       AMD GPU PRO EULA 
+Version:  	   %{repo}
+Release:       4%{?dist}
+License:       AMDGPU PRO  EULA NON-REDISTRIBUTABLE
 Group:         System Environment/Libraries
 URL:      http://repo.radeon.com/amdgpu
+
 Summary:       AMD OpenGL
+
+%undefine _disable_source_fetch
+Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libegl1-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_i386.deb
+Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-dri_%{major}-%{minor}~%{ubuntu}_i386.deb
+Source2:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-ext_%{major}-%{minor}~%{ubuntu}_i386.deb
+Source3:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-glx_%{major}-%{minor}~%{ubuntu}_i386.deb
+Source4:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libglapi1-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_i386.deb
+Source5:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgles2-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_i386.deb
+
+Provides:      libEGL.so.1()(64bit)  
+Provides:      libegl-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      libegl-amdgpu-pro(i686) = %{major}-%{minor}~%{ubuntu}
+Provides:      libglapi-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      libglapi-amdgpu-pro(i686) = %{major}-%{minor}~%{ubuntu}
+Provides:      libglapi.so.1()(64bit)  
+Provides:      libGLESv2.so.2()(64bit)  
+Provides:      libgles-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      libgles-amdgpu-pro(i686) = %{major}-%{minor}~%{ubuntu}
+Provides:      config(libgl-amdgpu-pro) = %{major}-%{minor}~%{ubuntu}
+Provides:      libGL.so.1()(64bit)  
+Provides:      libGLX_amd.so.0()(64bit)  
+Provides:      libgl-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro(i686) = %{major}-%{minor}~%{ubuntu}
+Provides:      config(libgl-amdgpu-pro-appprofiles) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-appprofiles = %{major}-%{minor}~%{ubuntu}
+Provides:      config(libgl-amdgpu-pro-dri) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-dri = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-dri(i686) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-ext = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-ext(i686) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-glx = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-glx(i686) = %{major}-%{minor}~%{ubuntu}
 
 BuildRequires: wget 
 BuildRequires: cpio
 
-Requires:      libdrm-pro  
+Requires:      libEGL.so.1()(64bit)    
+Requires:      libGLESv2.so.2()(64bit) 
+Requires:      config(libgl-amdgpu-pro) = %{major}-%{minor}~%{ubuntu}
+Requires:      libGLX_amd.so.0()(64bit)
+Requires:      config(libgl-amdgpu-pro-appprofiles) = %{major}-%{minor}~%{ubuntu}
+Requires:      config(libgl-amdgpu-pro-dri) = %{major}-%{minor}~%{ubuntu}
+Requires:      libGL.so.1()(64bit)  
+Requires:      libX11-xcb.so.1()(64bit)  
+Requires:      libX11.so.6()(64bit)  
+Requires:      libXdamage.so.1()(64bit)  
+Requires:      libXext.so.6()(64bit)  
+Requires:      libXfixes.so.3()(64bit)  
+Requires:      libXxf86vm.so.1()(64bit)  
+Requires:      libdrm.so.2()(64bit)  
+Requires:      libm.so.6()(64bit)  
+Requires:      libpthread.so.0()(64bit)  
+Requires:      libpthread.so.0(GLIBC_2.2.5)(64bit)  
+Requires:      libxcb-dri2.so.0()(64bit)  
+Requires:      libxcb-glx.so.0()(64bit)  
+Requires:      libxcb.so.1()(64bit)  
 
-Provides:      libEGL.so.1()  
-Provides:      libegl-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libegl-amdgpu-pro(i686) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libglapi-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libglapi-amdgpu-pro(i686) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libglapi.so.1()  
-Provides:      libGLESv2.so.2()  
-Provides:      libgles-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgles-amdgpu-pro(i686) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      config(libgl-amdgpu-pro) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libGL.so.1()  
-Provides:      libGLX_amd.so.0()  
-Provides:      libgl-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro(i686) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      config(libgl-amdgpu-pro-appprofiles) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-appprofiles = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      config(libgl-amdgpu-pro-dri) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-dri = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-dri(i686) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-ext = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-ext(i686) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-glx = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-glx(i686) = 0:%{major}-%{minor}.el%{rhel_minor}
-
-Requires:      libEGL.so.1()    
-Requires:      libGLESv2.so.2() 
-Requires:      config(libgl-amdgpu-pro) = 0:%{major}-%{minor}.el%{rhel_minor}
-Requires:      libGLX_amd.so.0()
-Requires:      config(libgl-amdgpu-pro-appprofiles) = 0:%{major}-%{minor}.el%{rhel_minor}
-Requires:      config(libgl-amdgpu-pro-dri) = 0:%{major}-%{minor}.el%{rhel_minor}
-Requires:      libGL.so.1  
-Requires:      libX11-xcb.so.1  
-Requires:      libX11.so.6  
-Requires:      libXdamage.so.1  
-Requires:      libXext.so.6  
-Requires:      libXfixes.so.3  
-Requires:      libXxf86vm.so.1  
-Requires:      libdrm.so.2  
-Requires:      libm.so.6
-Requires:      libpthread.so.0  
-Requires:      libpthread.so.0  
-Requires:      libxcb-dri2.so.0  
-Requires:      libxcb-glx.so.0  
-Requires:      libxcb.so.1  
-
-Recommends: amdgpu-opengl-switcher(x86_64)
+Requires:      libdrm-pro(i686) 
 
 Requires(post): /sbin/ldconfig  
 Requires(postun): /sbin/ldconfig 
 
-%build
-
-echo "pulling required packages off repo.radeon.com"
-
-mkdir -p %{buildroot}/debs
-
-cd %{buildroot}/debs
-
-wget http://repo.radeon.com/amdgpu/%{amdpro}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libegl1-amdgpu-pro_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-wget http://repo.radeon.com/amdgpu/%{amdpro}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-dri_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-wget http://repo.radeon.com/amdgpu/%{amdpro}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-ext_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-wget http://repo.radeon.com/amdgpu/%{amdpro}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-glx_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-wget http://repo.radeon.com/amdgpu/%{amdpro}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libglapi1-amdgpu-pro_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-wget http://repo.radeon.com/amdgpu/%{amdpro}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgles2-amdgpu-pro_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-###
-
-echo "extracting packages"
-
-mkdir -p %{buildroot}/debs/extract
-
-cd %{buildroot}/debs/extract
-
-####
-
-ar -x ../libegl1-amdgpu-pro_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-tar -xf data.tar.xz
-
-rm -r *.tar*
-
-rm debian-binary
-
-####
-
-ar -x ../libgl1-amdgpu-pro-dri_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-tar -xf data.tar.xz
-
-rm -r *.tar*
-
-rm debian-binary
-
-####
-
-ar -x ../libgl1-amdgpu-pro-ext_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-tar -xf data.tar.xz
-
-rm -r *.tar*
-
-rm debian-binary
-
-####
-
-ar -x ../libgl1-amdgpu-pro-glx_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-tar -xf data.tar.xz
-
-rm -r *.tar*
-
-rm debian-binary
-
-####
-
-ar -x ../libglapi1-amdgpu-pro_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-tar -xf data.tar.xz
-
-rm -r *.tar*
-
-rm debian-binary
-
-####
-
-ar -x ../libgles2-amdgpu-pro_"%{major}"-"%{minor}"~"%{ubuntu}"_i386.deb
-
-tar -xf data.tar.xz
-
-rm -r *.tar*
-
-rm debian-binary
-
-###
-
-cd %{buildroot}/debs/extract
-
-#
-
-echo "adapting to a mesa friendly environment"
-
-rm -r ./opt/amdgpu
-
-rm -r  ./etc/amd/amdrc
-
-rm -r   ./etc/ld.so.conf.d/10-amdgpu-pro-i386.conf
-
-#
-
-echo "restructuring package directories  "
-
-mkdir -p ./opt/amdgpu-pro/OpenGL
-
-mkdir -p ./opt/amdgpu-pro/OpenGL/lib32
-
-mv ./opt/amdgpu-pro/lib/i386-linux-gnu/* ./opt/amdgpu-pro/OpenGL/lib32/
-
-rm -r ./opt/amdgpu-pro/lib/i386-linux-gnu
-
-mv ./usr/lib/i386-linux-gnu/* ./opt/amdgpu-pro/OpenGL/lib32/
-
-rm -r ./usr/lib/i386-linux-gnu
-
-mv ./opt/amdgpu-pro/lib/* ./opt/amdgpu-pro/OpenGL/lib32
-
-rm -r ./opt/amdgpu-pro/lib
-
-rm -r ./usr
-
-# 
-
-#echo 'patching libs to use official libdrm'
-
-#sed -i "s|libdrm|libdro|g" ./opt/amdgpu-pro/OpenGL/lib32/*.so
-
-
-# 
-
-echo "adding *Disabled* library path"
-
-mkdir -p ./etc
-
-mkdir -p ./etc/ld.so.conf.d
-
-touch ./etc/ld.so.conf.d/amdogl-pro-i686.conf
-
-echo "# /opt/amdgpu-pro/OpenGL/lib32" > ./etc/ld.so.conf.d/amdogl-pro-i686.conf
-
-
-
-
-###
-
-mv ./opt %{buildroot}/
-mv ./etc %{buildroot}/
+Recommends: amdgpu-opengl-switcher(x86_64)
 
 %description
 Amdgpu Pro OpenGL driver
 
-%files
-%attr(0644, root, root) "/etc/ld.so.conf.d/amdogl-pro-i686.conf"
-%attr(0644, root, root) "/opt/amdgpu-pro/OpenGL/lib32/dri/amdgpu_dri.so"
-%attr(0777, root, root) "/opt/amdgpu-pro/OpenGL/lib32/libEGL.so"
-%attr(0644, root, root) "/opt/amdgpu-pro/OpenGL/lib32/libEGL.so.1"
-%attr(0777, root, root) "/opt/amdgpu-pro/OpenGL/lib32/libGLESv2.so"
-%attr(0644, root, root) "/opt/amdgpu-pro/OpenGL/lib32/libGLESv2.so.2"
-%attr(0777, root, root) "/opt/amdgpu-pro/OpenGL/lib32/libglapi.so"
-%attr(0644, root, root) "/opt/amdgpu-pro/OpenGL/lib32/libglapi.so.1"
-%attr(0644, root, root) "/opt/amdgpu-pro/OpenGL/lib32/xorg/modules/extensions/libglx.so"
-%attr(0644, root, root) "/opt/amdgpu-pro/OpenGL/lib32/libGL*"
-%attr(0644, root, root) "/opt/amdgpu-pro/OpenGL/lib32/libGLX_amd*"
-%exclude "/debs"
+%prep
+mkdir -p files
 
+ar x --output . %{SOURCE0}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+ar x --output . %{SOURCE1}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+ar x --output . %{SOURCE2}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+ar x --output . %{SOURCE3}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+ar x --output . %{SOURCE4}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+ar x --output . %{SOURCE5}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+%install
+mkdir -p %{buildroot}/opt/amdgpu/share/drirc.d
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/dri
+#
+install -p -m755 files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
+install -p -m755 files/opt/amdgpu-pro/lib/xorg/modules/extensions/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
+install -p -m755 files/usr/lib/i386-linux-gnu/dri/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/dri
+#
+echo "adding *Disabled* library path"
+mkdir -p %{buildroot}/etc/ld.so.conf.d
+touch %{buildroot}/etc/ld.so.conf.d/amdogl-pro-%{_arch}.conf
+echo "#/opt/amdgpu-pro/opengl/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdogl-pro-%{_arch}.conf
+
+%files
+"/etc/ld.so.conf.d/amdogl-pro-%{_arch}.conf"
+"/opt/amdgpu-pro/opengl/%{_lib}/dri/amdgpu_dri.so"
+"/opt/amdgpu-pro/opengl/%{_lib}/libEGL*"
+"/opt/amdgpu-pro/opengl/%{_lib}/libGL*"
+"/opt/amdgpu-pro/opengl/%{_lib}/libgl*"
 
 %post
 /sbin/ldconfig

--- a/i686/amdogl-pro.i686/amdogl-pro.i686.spec
+++ b/i686/amdogl-pro.i686/amdogl-pro.i686.spec
@@ -117,9 +117,9 @@ mkdir -p %{buildroot}/opt/amdgpu/share/drirc.d
 mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}
 mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/dri
 #
-install -p -m755 files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
-install -p -m755 files/opt/amdgpu-pro/lib/xorg/modules/extensions/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
-install -p -m755 files/usr/lib/i386-linux-gnu/dri/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/dri
+cp -r files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
+cp -r files/opt/amdgpu-pro/lib/xorg/modules/extensions/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
+cp -r files/usr/lib/i386-linux-gnu/dri/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/dri
 #
 echo "adding *Disabled* library path"
 mkdir -p %{buildroot}/etc/ld.so.conf.d

--- a/i686/amdvlk-pro-legacy.i686/amdvlk-pro-legacy.i686.spec
+++ b/i686/amdvlk-pro-legacy.i686/amdvlk-pro-legacy.i686.spec
@@ -61,8 +61,8 @@ tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan-legacy/%{_lib}
 mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/
 #
-install -p -m755 files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/%{_lib}/
-install -p -m755 files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/
+cp -r files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/%{_lib}/
+cp -r files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/
 #
 echo "fixing .icds "
 sed -i "s#/opt/amdgpu-pro/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu-pro/vulkan-legacy/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/amd_icd32.json"

--- a/i686/amdvlk-pro-legacy.i686/amdvlk-pro-legacy.i686.spec
+++ b/i686/amdvlk-pro-legacy.i686/amdvlk-pro-legacy.i686.spec
@@ -1,9 +1,9 @@
 %define _build_id_links none
 
 # global info
-%global repo 22.20.3
-%global major 22.20
-%global minor 1462318
+%global repo 21.40.2
+%global major 21.40.2
+%global minor 1350682
 # pkg info
 %global amf 1.4.26
 %global enc 1.0
@@ -14,9 +14,9 @@
 %global amdgpu 1.0.0.50203
 # Distro info
 %global fedora fc36
-%global ubuntu 22.04
+%global ubuntu 20.04
 
-Name:     amdvlk-pro
+Name:     amdvlk-pro-legacy
 Version:  %{repo}
 Release:  4%{?dist}
 License:       AMDGPU PRO  EULA NON-REDISTRIBUTABLE
@@ -25,7 +25,7 @@ Summary:       AMD Vulkan
 URL:      http://repo.radeon.com/amdgpu
 
 %undefine _disable_source_fetch
-Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/v/vulkan-amdgpu-pro/vulkan-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_i386.deb
+Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/v/vulkan-amdgpu-pro/vulkan-amdgpu-pro_%{major}-%{minor}_i386.deb
 
 Provides:      config(amdvlk-pro) = %{major}-%{release}
 Provides:      amdvlk-pro = %{major}-%{release}
@@ -58,28 +58,24 @@ ar x --output . %{SOURCE0}
 tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 %install
-mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan/%{_lib}
-mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/
-mkdir -p %{buildroot}/opt/amdgpu-pro/etc/vulkan/icd.d/
+mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan-legacy/%{_lib}
+mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/
 #
-install -p -m755 files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan/%{_lib}/
-install -p -m755 files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/
+install -p -m755 files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/%{_lib}/
+install -p -m755 files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/
 #
 echo "fixing .icds "
-sed -i "s#/opt/amdgpu-pro/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu-pro/vulkan/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/amd_icd32.json"
-#
-ln -s /opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/amd_icd32.json %{buildroot}/opt/amdgpu-pro/etc/vulkan/icd.d/
+sed -i "s#/opt/amdgpu-pro/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu-pro/vulkan-legacy/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/amd_icd32.json"
 #
 echo "adding *Disabled* library path"
 mkdir -p %{buildroot}/etc/ld.so.conf.d
-touch %{buildroot}/etc/ld.so.conf.d/amdvlk-pro-%{_arch}.conf
-echo "#/opt/amdgpu-pro/vulkan/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-pro-%{_arch}.conf
+touch %{buildroot}/etc/ld.so.conf.d/amdvlk-pro-legacy-%{_arch}.conf
+echo "#/opt/amdgpu-pro/vulkan-legacy/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-pro-legacy-%{_arch}.conf
 
 %files
-"/etc/ld.so.conf.d/amdvlk-pro-%{_arch}.conf"
-"/opt/amdgpu-pro/etc/vulkan/icd.d/amd_icd32.json"
-"/opt/amdgpu-pro/vulkan/%{_lib}/amdvlk32*"
-"/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/amd_icd32.json"
+"/etc/ld.so.conf.d/amdvlk-pro-legacy-%{_arch}.conf"
+"/opt/amdgpu-pro/vulkan-legacy/%{_lib}/amdvlk32*"
+"/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/amd_icd32.json"
 
 %post
 /sbin/ldconfig

--- a/i686/amdvlk-pro.i686/amdvlk-pro.i686.spec
+++ b/i686/amdvlk-pro.i686/amdvlk-pro.i686.spec
@@ -62,8 +62,8 @@ mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan/%{_lib}
 mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/
 mkdir -p %{buildroot}/opt/amdgpu-pro/etc/vulkan/icd.d/
 #
-install -p -m755 files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan/%{_lib}/
-install -p -m755 files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/
+cp -r files/opt/amdgpu-pro/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan/%{_lib}/
+cp -r files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/
 #
 echo "fixing .icds "
 sed -i "s#/opt/amdgpu-pro/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu-pro/vulkan/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/amd_icd32.json"

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -66,9 +66,9 @@ mkdir -p %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
 mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
 mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/icd.d
 #
-install -p -m755 files/usr/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu/vulkan/%{_lib}/
-install -p -m755 files/etc/vulkan/implicit_layer.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
-install -p -m755 files/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
+cp -r files/usr/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu/vulkan/%{_lib}/
+cp -r files/etc/vulkan/implicit_layer.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
+cp -r files/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
 #
 echo "fixing .icds "
 sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd32.json"

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -1,18 +1,25 @@
-%undefine _auto_set_build_flags
-%global amdpro 22.20.3
+%define _build_id_links none
+
+# global info
+%global repo 22.20.3
 %global major 22.20
 %global minor 1462318
+# pkg info
 %global amf 1.4.26
 %global enc 1.0
-%global rhel_major 9.0
-%global rhel_minor 9
+#
 %global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global amdgpu 1.0.0.50203
+# Distro info
 %global fedora fc36
 %global ubuntu 22.04
 
+
 Name:          amdvlk
 Version:       %{amdvlk}
-Release:       3
+Release:       4
 License:       MIT 
 Group:         System Environment/Libraries
 Summary:       AMD Open Source Driver for Vulkan
@@ -20,88 +27,68 @@ Summary:       AMD Open Source Driver for Vulkan
 URL:           https://github.com/GPUOpen-Drivers/AMDVLK
 Vendor:        Advanced Micro Devices (AMD)
 
-Provides:      amdvlk = %{amdvlk}-3
-Provides:      amdvlk(i686) = %{amdvlk}-3
-Provides:      config(amdvlk) = %{amdvlk}-3
-Requires:      config(amdvlk) = %{amdvlk}-3
-Requires:      vulkan-loader
+%undefine _disable_source_fetch
+Source0 :  http://repo.radeon.com/amdvlk/apt/debian/pool/main/a/amdvlk/amdvlk_%{amdvlk}_i386.deb
 
-Requires:      libdrm-pro  
+Provides:      amdvlk = %{amdvlk}-%{release}
+Provides:      amdvlk(x86_64) = %{amdvlk}-%{release}
+Provides:      config(amdvlk) = %{amdvlk}-%{release}
+Provides:      vulkan-amdgpu = %{major}-%{minor}~%{ubuntu}
+Provides:      vulkan-amdgpu(i386) = %{major}-%{minor}~%{ubuntu}
+
+Recommends:	 openssl-libs  
 
 BuildRequires: wget 
 BuildRequires: cpio
 
-Recommends:	 openssl-libs  
+Requires(post): /sbin/ldconfig  
+Requires(postun): /sbin/ldconfig 
 
-%build
+Requires:      config(amdvlk) = %{amdvlk}-%{release}
+Requires:      vulkan-loader
+Requires:      libdrm-pro(i686) 
 
-echo "pulling required packages off repo.radeon.com"
-
-mkdir -p %{buildroot}/debs
-
-cd %{buildroot}/debs
-
-wget http://repo.radeon.com/amdvlk/apt/debian/pool/main/a/amdvlk/amdvlk_"%{amdvlk}"_i386.deb
-
-###
-
-echo "extracting packages"
-
-mkdir -p %{buildroot}/debs/extract
-
-cd %{buildroot}/debs/extract
-
-ar -x ../amdvlk_"%{amdvlk}"_i386.deb
-
-tar -xf data.tar.gz
-
-rm -r *.tar*
-
-rm debian-binary
-
-###
-
-#
-
-echo "restructuring package directories  "
-
-cd %{buildroot}/debs/extract
-
-mkdir -p ./opt/amdgpu/vulkan
-
-mv ./usr/lib/i386-linux-gnu ./opt/amdgpu/vulkan/lib32
-
-rm -r ./usr/share
-
-#
-
-echo "fixing .icds "
-
-sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu/vulkan/lib32/amdvlk32.so#" "./etc/vulkan/icd.d/amd_icd32.json"
-
-# we don't need this one
-rm ./etc/vulkan/implicit_layer.d/amd_icd32.json
-
-###
-
-# 
-
-#echo 'patching libs to use official libdrm'
-
-#sed -i "s|libdrm|libdro|g" ./opt/amdgpu/vulkan/lib32/*.so
-
-#
-
-mv ./opt %{buildroot}/
-mv ./etc %{buildroot}/opt/amdgpu/
-
-%files
-"/opt/amdgpu/etc/vulkan/icd.d/amd_icd32.json"
-"/opt/amdgpu/vulkan/lib32/amdvlk32.so"
-%exclude "/debs"
+Recommends:	 amdgpu-vulkan-switcher(x86_64)
 
 %description
 AMD Open Source Driver for Vulkan
+
+%prep
+mkdir -p files
+
+ar x --output . %{SOURCE0}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+%install
+mkdir -p %{buildroot}/opt/amdgpu/vulkan/%{_lib}
+mkdir -p %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
+mkdir -p %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
+mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
+mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/icd.d
+#
+install -p -m755 files/usr/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu/vulkan/%{_lib}/
+install -p -m755 files/etc/vulkan/implicit_layer.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
+install -p -m755 files/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
+#
+echo "fixing .icds "
+sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd32.json"
+sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd32.json"
+#
+ln -s /opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd32.json %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
+ln -s /opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd32.json %{buildroot}/opt/amdgpu/etc/vulkan/icd.d/
+#
+echo "adding *Disabled* library path"
+mkdir -p %{buildroot}/etc/ld.so.conf.d
+touch %{buildroot}/etc/ld.so.conf.d/amdvlk-%{_arch}.conf
+echo "#/opt/amdgpu/vulkan/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-%{_arch}.conf
+
+%files
+"/etc/ld.so.conf.d/amdvlk-%{_arch}.conf"
+"/opt/amdgpu/etc/vulkan/icd.d/amd_icd32.json"
+"/opt/amdgpu/etc/vulkan/implicit_layer.d/amd_icd32.json"
+"/opt/amdgpu/vulkan/%{_lib}/amdvlk32.so"
+"/opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd32.json"
+"/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd32.json"
 
 %post
 /sbin/ldconfig

--- a/i686/libdrm-pro.i686/libdrm-pro.i686.spec
+++ b/i686/libdrm-pro.i686/libdrm-pro.i686.spec
@@ -1,146 +1,98 @@
-%undefine _auto_set_build_flags
-%global amdpro 22.20.3
+%define _build_id_links none
+
+# global info
+%global repo 22.20.3
 %global major 22.20
 %global minor 1462318
+# pkg info
 %global amf 1.4.26
 %global enc 1.0
-%global rhel_major 9.0
-%global rhel_minor 9
+#
 %global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global amdgpu 1.0.0.50203
+# Distro info
 %global fedora fc36
 %global ubuntu 22.04
 
 Name:     libdrm-pro
-Version:       %{amdpro}
-Release:       3.%{fedora}
-License:       AMD GPU PRO EULA 
+Version:  %{repo}
+Release:  4%{?dist}
+License:       AMDGPU PRO  EULA NON-REDISTRIBUTABLE
 Group:         System Environment/Libraries
 Summary:       AMD proprietary libdrm
 URL:      http://repo.radeon.com/amdgpu
 
+%undefine _disable_source_fetch
+Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu/libdrm-amdgpu-amdgpu1_%{drm}-%{minor}~%{ubuntu}_i386.deb
+Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu/libdrm-amdgpu-radeon1_%{drm}-%{minor}~%{ubuntu}_i386.deb
+Source2:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu/libdrm2-amdgpu_%{drm}-%{minor}~%{ubuntu}_i386.deb
+
 Provides:      libdrm-pro
 Provides:      libdrm-pro(i686)
+
 Provides:      libdrm.so.2()
 Provides:      libdrm_amdgpu.so.1()
 Provides:      libdrm_radeon.so.1()
 Provides:      libdrm.so.2()(i686)
 Provides:      libdrm_amdgpu.so.1()(i686)
 Provides:      libdrm_radeon.so.1()(i686)
-Provides:      libdrm.so.2()(x86_32)
-Provides:      libdrm_amdgpu.so.1()(x86_32)
-Provides:      libdrm_radeon.so.1()(x86_32)
 Provides:      libdrm.so.2()(32bit)
 Provides:      libdrm_amdgpu.so.1()(32bit)
 Provides:      libdrm_radeon.so.1()(32bit)
 
-Requires: 	libdrm-pro(x86_64)
-Requires: 	libdrm
+Provides:      libdrm-amdgpu = %{drm}-%{minor}~%{ubuntu}
+Provides:      libdrm-amdgpu-common = %{amdgpu}-%{minor}~%{ubuntu}
+
+Provides:      libdrm-amdgpu-amdgpu1 = %{drm}-%{minor}~%{ubuntu}
+Provides:      libdrm-amdgpu-radeon1 = %{drm}-%{minor}~%{ubuntu}
+Provides:      libdrm2-amdgpu = %{drm}-%{minor}~%{ubuntu}
+
+
 
 BuildRequires: wget 
 BuildRequires: cpio
 
-%build
+Requires(post): /sbin/ldconfig  
+Requires(postun): /sbin/ldconfig 
 
-echo "pulling required packages off repo.radeon.com"
+Requires: 	libdrm-pro(x86_64)
 
-mkdir -p %{buildroot}/debs
-
-cd %{buildroot}/debs
-
-wget -r -nd --no-parent -A 'libdrm-amdgpu-amdgpu1*%{ubuntu}_i386.deb' https://repo.radeon.com/amdgpu/"%{amdpro}"/ubuntu/pool/main/libd/libdrm-amdgpu/
-
-wget -r -nd --no-parent -A 'libdrm-amdgpu-radeon1*%{ubuntu}_i386.deb' https://repo.radeon.com/amdgpu/"%{amdpro}"/ubuntu/pool/main/libd/libdrm-amdgpu/
-
-wget -r -nd --no-parent -A 'libdrm2-amdgpu*%{ubuntu}_i386.deb' https://repo.radeon.com/amdgpu/"%{amdpro}"/ubuntu/pool/main/libd/libdrm-amdgpu/
-
-###
-
-echo "extracting packages"
-
-mkdir -p %{buildroot}/debs/extract
-
-cd %{buildroot}/debs/extract
-
-#
-
-ar -x ../libdrm-amdgpu-amdgpu1*%{ubuntu}_i386.deb
-
-tar -xf data.tar.*
-
-rm -r *.tar*
-
-rm debian-binary
-
-#
-
-ar -x ../libdrm-amdgpu-radeon1*%{ubuntu}_i386.deb
-
-tar -xf data.tar.*
-
-rm -r *.tar*
-
-rm debian-binary
-
-#
-
-ar -x ../libdrm2-amdgpu*%{ubuntu}_i386.deb
-
-tar -xf data.tar.*
-
-rm -r *.tar*
-
-rm debian-binary
-
-###
-
-#
-
-echo "restructuring package directories  "
-
-cd %{buildroot}/debs/extract
-
-mkdir -p ./opt/amdgpu/libdrm/lib32
-
-mv ./opt/amdgpu/lib/i386-linux-gnu/libdrm.so.2.4.0 ./opt/amdgpu/libdrm/lib32/
-
-mv ./opt/amdgpu/lib/i386-linux-gnu/libdrm_amdgpu.so.1.0.0 ./opt/amdgpu/libdrm/lib32/
-
-mv ./opt/amdgpu/lib/i386-linux-gnu/libdrm_radeon.so.1.0.1 ./opt/amdgpu/libdrm/lib32/
-
-#
-
-ln -s /opt/amdgpu/libdrm/lib32/libdrm.so.2.4.0 ./opt/amdgpu/libdrm/lib32/libdrm.so.2
-
-ln -s /opt/amdgpu/libdrm/lib32/libdrm_amdgpu.so.1.0.0 ./opt/amdgpu/libdrm/lib32/libdrm_amdgpu.so.1
-
-ln -s /opt/amdgpu/libdrm/lib32/libdrm_radeon.so.1.0.1 ./opt/amdgpu/libdrm/lib32/libdrm_radeon.so.1
-
-#
-
-ln -s /opt/amdgpu/libdrm/lib32/libdrm.so.2.4.0 ./opt/amdgpu/libdrm/lib32/libdrm.so
-
-ln -s /opt/amdgpu/libdrm/lib32/libdrm_amdgpu.so.1.0.0 ./opt/amdgpu/libdrm/lib32/libdrm_amdgpu.so
-
-ln -s /opt/amdgpu/libdrm/lib32/libdrm_radeon.so.1.0.1 ./opt/amdgpu/libdrm/lib32/libdrm_radeon.so
-
-# 
-
-rm -r ./usr/share
-
-# 
-
-cd %{buildroot}/debs/extract
-
-mv opt %{buildroot}/
-rm -r %{buildroot}/usr/lib/.build-id || echo 'no build-ids :)'
+Requires: 	libdrm
 
 %description
 AMD proprietary libdrm
 
+%prep
+mkdir -p files
+
+ar x --output . %{SOURCE0}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+ar x --output . %{SOURCE1}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+ar x --output . %{SOURCE2}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+%install
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/%{_lib}
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/libdrm
+#
+install -p -m755 files/opt/amdgpu/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu/libdrm/%{_lib}/
+#
+echo "adding *Disabled* library path"
+mkdir -p %{buildroot}/etc/ld.so.conf.d
+touch %{buildroot}/etc/ld.so.conf.d/libdrm-pro-%{_arch}.conf
+echo "#/opt/amdgpu/libdrm/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/libdrm-pro-%{_arch}.conf
+
 %files
-"/opt/amdgpu/libdrm/lib32/*.so*"
-%exclude "/debs"
-%exclude "/opt/amdgpu/lib/i386-linux-gnu"
+"/etc/ld.so.conf.d/libdrm-pro-%{_arch}.conf"
+"/opt/amdgpu/libdrm/%{_lib}/*drm*"
 
 %post
 /sbin/ldconfig

--- a/i686/libdrm-pro.i686/libdrm-pro.i686.spec
+++ b/i686/libdrm-pro.i686/libdrm-pro.i686.spec
@@ -83,7 +83,7 @@ mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1
 mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu
 mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/libdrm
 #
-install -p -m755 files/opt/amdgpu/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu/libdrm/%{_lib}/
+cp -r files/opt/amdgpu/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu/libdrm/%{_lib}/
 #
 echo "adding *Disabled* library path"
 mkdir -p %{buildroot}/etc/ld.so.conf.d

--- a/package-builder.sh
+++ b/package-builder.sh
@@ -16,13 +16,20 @@ if [[ -z $1  ]]; then
 fi
 
 # install some build dependencies
-sudo dnf -y install wget cpio mock pykickstart fedpkg libvirt
+sudo dnf -y install wget cpio mock pykickstart fedpkg libvirt fedora-packager rpmdevtools
 
 # turn selinux off if it's enabled
 sudo setenforce 0
 
 # make a destination folder for our packages
 mkdir -p packages
+
+# Setup tree
+mkdir -p SOURCES
+mkdir -p SPECS
+mkdir -p SRPMS
+mkdir -p BUILD
+mkdir -p BUILDROOT
 
 # enter the repository of the package to build:
 if [[ "$2" == "32" ]]; then
@@ -33,16 +40,26 @@ else
 	cd x86_64/$1
 fi
 
+
+
 # build the package
 rpmbuild -bb --define "_srcrpmdir $(pwd)/../../packages " --undefine=_disable_source_fetch  --target="$BUILDARCH" *.spec --define "_topdir $(pwd)/../.." --define "_rpmdir $(pwd)/../../packages"
 
-mv ../../packages/x86_64/* ../../packages/ || echo 'not a 64 bit package , this is ok!'
-
-mv ../../packages/i686/* ../../packages/ || echo 'not a 32 bit package , this is ok!'
 
 # enter main dir
 
 cd ../../
+
+# Clean
+rm -r BUILD
+rm -r BUILDROOT
+
+# Move rpms to packages
+
+mv packages/x86_64/* packages/ || echo 'not a 64 bit package , this is ok!'
+
+mv packages/i686/* packages/ || echo 'not a 32 bit package , this is ok!'
+
 
 # re-enable selinux if needed
 sudo setenforce 1

--- a/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
+++ b/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
@@ -70,9 +70,9 @@ mkdir -p %{buildroot}/opt/amdgpu-pro/amf/%{_lib}
 mkdir -p %{buildroot}/opt/amdgpu-pro/amf/share/licenses/amf-amdgpu-pro
 mkdir -p %{buildroot}/opt/amdgpu-pro/amf/share/licenses/libamdenc-amdgpu-pro
 #
-install -p -m755 files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/amf/%{_lib}/
-install -p -m755 files/usr/share/doc/amf-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/amf/share/licenses/amf-amdgpu-pro/LICENSE
-install -p -m755 files/usr/share/doc/libamdenc-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/amf/share/licenses/libamdenc-amdgpu-pro/LICENSE
+cp -r files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/amf/%{_lib}/
+cp -r files/usr/share/doc/amf-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/amf/share/licenses/amf-amdgpu-pro/LICENSE
+cp -r files/usr/share/doc/libamdenc-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/amf/share/licenses/libamdenc-amdgpu-pro/LICENSE
 #
 mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
 ln -s /opt/amdgpu-pro/amf/share/licenses/amf-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/amf-amdgpu-pro

--- a/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
+++ b/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
@@ -60,10 +60,10 @@ System runtime for AMD Advanced Media Framework
 mkdir -p files
 
 ar x --output . %{SOURCE0}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE1}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 %install
 mkdir -p %{buildroot}/opt/amdgpu-pro/amf/%{_lib}

--- a/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
+++ b/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
@@ -9,7 +9,7 @@
 %global amdvlk 2022.Q3.3
 #
 %global drm 2.4.110.50203
-%global drm-common 1.0.0.50203
+%global amdgpu 1.0.0.50203
 # Distro info
 %global fedora fc36
 %global ubuntu 22.04

--- a/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
+++ b/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
@@ -30,12 +30,12 @@ Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/a/amf-am
 Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/liba/libamdenc-amdgpu-pro/libamdenc-amdgpu-pro_%{enc}-%{minor}~%{ubuntu}_amd64.deb
 
 Provides:      amf-runtime = %{major}-%{release}
-Provides:      amf-runtime(x86-64) = %{major}-%{release}
+Provides:      amf-runtime(x86_64) = %{major}-%{release}
 Provides:      amf-amdgpu-pro = %{amf}-%{minor}~%{ubuntu}
-Provides:      amf-amdgpu-pro(x86-64) = %{amf}-%{minor}~%{ubuntu}
+Provides:      amf-amdgpu-pro(x86_64) = %{amf}-%{minor}~%{ubuntu}
 Provides:      libamfrt64.so.1()(64bit) 
 Provides:      libamdenc-amdgpu-pro = %{enc}-%{minor}~%{ubuntu}
-Provides:      libamdenc-amdgpu-pro(x86-64) = %{enc}-%{minor}~%{ubuntu}
+Provides:      libamdenc-amdgpu-pro(x86_64) = %{enc}-%{minor}~%{ubuntu}
 Provides:      libamdenc64.so.1.0()(64bit)  
 Provides:      libamdenc64.so.1.0()(64bit)  
 

--- a/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
+++ b/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
@@ -1,3 +1,5 @@
+%define _build_id_links none
+
 # global info
 %global repo 22.20.3
 %global major 22.20

--- a/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
+++ b/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
@@ -88,3 +88,9 @@ echo "/opt/amdgpu-pro/amf/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amf-runtime-%
 "/opt/amdgpu-pro/amf/share/licenses/amf-amdgpu-pro/LICENSE"
 "/opt/amdgpu-pro/amf/share/licenses/libamdenc-amdgpu-pro/LICENSE"
 "/opt/amdgpu-pro/share/*"
+
+%post
+/sbin/ldconfig
+
+%postun
+/sbin/ldconfig

--- a/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
+++ b/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
@@ -1,30 +1,39 @@
-%undefine _auto_set_build_flags
-%global amdpro 22.20.3
+# global info
+%global repo 22.20.3
 %global major 22.20
 %global minor 1462318
+# pkg info
 %global amf 1.4.26
 %global enc 1.0
-%global rhel_major 9.0
-%global rhel_minor 9
+#
 %global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global drm-common 1.0.0.50203
+# Distro info
 %global fedora fc36
 %global ubuntu 22.04
 
 Name:     amdamf-pro-runtime
-Version:  %{amdpro}
-Release:  3.%{fedora}
-License:       AMD GPU PRO EULA 
+Version:  %{repo}
+Release:  4%{?dist}
+License:       AMDGPU PRO  EULA NON-REDISTRIBUTABLE
 Group:         System Environment/Libraries
 Summary:       System runtime for AMD Advanced Media Framework
 URL:      http://repo.radeon.com/amdgpu
 
-Provides:      amf-runtime = %{major}-3.%{fedora}
-Provides:      amf-runtime(x86-64) = %{major}-3.%{fedora}
-Provides:      amf-amdgpu-pro = 0:%{amf}-%{minor}.el%{rhel_minor}
-Provides:      amf-amdgpu-pro(x86-64) = 0:%{amf}-%{minor}.el%{rhel_minor}
+
+%undefine _disable_source_fetch
+Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/a/amf-amdgpu-pro/amf-amdgpu-pro_%{amf}-%{minor}~%{ubuntu}_amd64.deb
+Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/liba/libamdenc-amdgpu-pro/libamdenc-amdgpu-pro_%{enc}-%{minor}~%{ubuntu}_amd64.deb
+
+Provides:      amf-runtime = %{major}-%{release}
+Provides:      amf-runtime(x86-64) = %{major}-%{release}
+Provides:      amf-amdgpu-pro = 0:%{amf}-%{minor}~%{ubuntu}
+Provides:      amf-amdgpu-pro(x86-64) = 0:%{amf}-%{minor}~%{ubuntu}
 Provides:      libamfrt64.so.1()(64bit) 
-Provides:      libamdenc-amdgpu-pro = 0:%{enc}-%{minor}.el%{rhel_minor}
-Provides:      libamdenc-amdgpu-pro(x86-64) = 0:%{enc}-%{minor}.el%{rhel_minor}
+Provides:      libamdenc-amdgpu-pro = 0:%{enc}-%{minor}~%{ubuntu}
+Provides:      libamdenc-amdgpu-pro(x86-64) = 0:%{enc}-%{minor}~%{ubuntu}
 Provides:      libamdenc64.so.1.0()(64bit)  
 Provides:      libamdenc64.so.1.0()(64bit)  
 
@@ -40,85 +49,42 @@ Requires:      vulkan-amdgpu-pro
 Requires:      libdrm-pro
 Requires:      opencl-filesystem
 
-
 Recommends:	 rocm-opencl-runtime  
 
-
-%build
-
-echo "pulling required packages off repo.radeon.com"
-
-mkdir -p %{buildroot}/rpms
-
-cd %{buildroot}/rpms
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}"/rhel/"%{rhel_major}"/proprietary/x86_64/amf-amdgpu-pro-"%{amf}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}"/rhel/"%{rhel_major}"/proprietary/x86_64/libamdenc-amdgpu-pro-"%{enc}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm
-
-###
-
-echo "extracting packages"
-
-mkdir -p %{buildroot}/rpms/extract
-
-cd %{buildroot}/rpms/extract
-
-rpm2cpio ../amf-amdgpu-pro-"%{amf}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm | cpio -idmv
-
-rpm2cpio ../libamdenc-amdgpu-pro-"%{enc}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm | cpio -idmv
-
-###
-
-#
-
-echo "restructuring package directories  "
-
-cd %{buildroot}/rpms/extract
-
-mkdir -p ./opt/amdgpu-pro/amf
-
-mv ./opt/amdgpu-pro/lib64 ./opt/amdgpu-pro/amf/
-
-# 
-
-#echo 'patching libs to use official libdrm'
-
-#sed -i "s|libdrm|libdro|g" ./opt/amdgpu-pro/amf/lib64/*.so
-
-#
-
-echo "adding library path"
-
-mkdir -p ./etc
-
-mkdir -p ./etc/ld.so.conf.d
-
-touch ./etc/ld.so.conf.d/amf-runtime-x86_64.conf
-
-echo "/opt/amdgpu-pro/amf/lib64" > ./etc/ld.so.conf.d/amf-runtime-x86_64.conf
-
-cd %{buildroot}/rpms/extract
-
-mv ./opt %{buildroot}/
-mv ./usr %{buildroot}/
-mv ./etc %{buildroot}/
-rm -r %{buildroot}/usr/lib/.build-id || echo 'no build-ids :)'
-
 %description
-Amd encode library
+System runtime for AMD Advanced Media Framework
+
+%prep
+mkdir -p files
+
+ar x --output . %{SOURCE0}
+tar -xJC files -f data.tar.xz
+
+ar x --output . %{SOURCE1}
+tar -xJC files -f data.tar.xz
+
+%install
+mkdir -p %{buildroot}/opt/amdgpu-pro/amf/%{_lib}
+mkdir -p %{buildroot}/opt/amdgpu-pro/amf/share/licenses/amf-amdgpu-pro
+mkdir -p %{buildroot}/opt/amdgpu-pro/amf/share/licenses/libamdenc-amdgpu-pro
+#
+install -p -m755 files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/amf/%{_lib}/
+install -p -m755 files/usr/share/doc/amf-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/amf/share/licenses/amf-amdgpu-pro/LICENSE
+install -p -m755 files/usr/share/doc/libamdenc-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/amf/share/licenses/libamdenc-amdgpu-pro/LICENSE
+#
+mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
+ln -s /opt/amdgpu-pro/amf/share/licenses/amf-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/amf-amdgpu-pro
+ln -s /opt/amdgpu-pro/amf/share/licenses/libamdenc-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/libamdenc-amdgpu-pro
+#
+echo "adding library path"
+mkdir -p %{buildroot}/etc/ld.so.conf.d
+touch %{buildroot}/etc/ld.so.conf.d/amf-runtime-%{_arch}.conf
+echo "/opt/amdgpu-pro/amf/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amf-runtime-%{_arch}.conf
 
 %files
-"/etc/ld.so.conf.d/amf-runtime-x86_64.conf"
-"/opt/amdgpu-pro/amf/lib64/libamdenc64.so"
-"/opt/amdgpu-pro/amf/lib64/libamdenc64.so.1.0"
-"/opt/amdgpu-pro/amf/lib64/libamfrt64.so*"
-"/opt/amdgpu-pro/share/licenses/amf-amdgpu-pro/AMDGPUPROEULA"
-"/opt/amdgpu-pro/share/licenses/libamdenc-amdgpu-pro/AMDGPUPROEULA"
-%exclude "/rpms"
-
-%post
-/sbin/ldconfig
-
-%postun
-/sbin/ldconfig
+"/etc/ld.so.conf.d/amf-runtime-%{_arch}.conf"
+"/opt/amdgpu-pro/amf/lib64/libamf*"
+"/opt/amdgpu-pro/amf/lib64/libamdenc*"
+"/opt/amdgpu-pro/amf/share/licenses/amf-amdgpu-pro/LICENSE"
+"/opt/amdgpu-pro/amf/share/licenses/libamdenc-amdgpu-pro/LICENSE"
+"/opt/amdgpu-pro/share/*"

--- a/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
+++ b/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
@@ -29,11 +29,11 @@ Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/liba/lib
 
 Provides:      amf-runtime = %{major}-%{release}
 Provides:      amf-runtime(x86-64) = %{major}-%{release}
-Provides:      amf-amdgpu-pro = 0:%{amf}-%{minor}~%{ubuntu}
-Provides:      amf-amdgpu-pro(x86-64) = 0:%{amf}-%{minor}~%{ubuntu}
+Provides:      amf-amdgpu-pro = %{amf}-%{minor}~%{ubuntu}
+Provides:      amf-amdgpu-pro(x86-64) = %{amf}-%{minor}~%{ubuntu}
 Provides:      libamfrt64.so.1()(64bit) 
-Provides:      libamdenc-amdgpu-pro = 0:%{enc}-%{minor}~%{ubuntu}
-Provides:      libamdenc-amdgpu-pro(x86-64) = 0:%{enc}-%{minor}~%{ubuntu}
+Provides:      libamdenc-amdgpu-pro = %{enc}-%{minor}~%{ubuntu}
+Provides:      libamdenc-amdgpu-pro(x86-64) = %{enc}-%{minor}~%{ubuntu}
 Provides:      libamdenc64.so.1.0()(64bit)  
 Provides:      libamdenc64.so.1.0()(64bit)  
 

--- a/x86_64/amdocl-legacy/amdocl-legacy.spec
+++ b/x86_64/amdocl-legacy/amdocl-legacy.spec
@@ -9,7 +9,7 @@
 %global amdvlk 2022.Q3.3
 #
 %global drm 2.4.110.50203
-%global drm-common 1.0.0.50203
+%global amdgpu 1.0.0.50203
 # Distro info
 %global fedora fc36
 %global ubuntu 22.04

--- a/x86_64/amdocl-legacy/amdocl-legacy.spec
+++ b/x86_64/amdocl-legacy/amdocl-legacy.spec
@@ -1,3 +1,5 @@
+%define _build_id_links none
+
 # global info
 %global repo 22.20.3
 %global major 22.20

--- a/x86_64/amdocl-legacy/amdocl-legacy.spec
+++ b/x86_64/amdocl-legacy/amdocl-legacy.spec
@@ -72,10 +72,10 @@ mkdir -p %{buildroot}/etc/OpenCL/vendors/
 mkdir -p %{buildroot}/opt/amdgpu-pro/opencl/share/licenses/opencl-legacy-amdgpu-pro-icd
 mkdir -p %{buildroot}/opt/amdgpu-pro/opencl/share/licenses/ocl-icd-libopencl1-amdgpu-pro
 #
-install -p -m755 files/etc/OpenCL/vendors/* %{buildroot}/etc/OpenCL/vendors/
-install -p -m755 files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opencl/%{_lib}/
-install -p -m755 files/usr/share/doc/opencl-legacy-amdgpu-pro-icd/copyright %{buildroot}/opt/amdgpu-pro/opencl/share/licenses/opencl-legacy-amdgpu-pro-icd/LICENSE
-install -p -m755 files/usr/share/doc/ocl-icd-libopencl1-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opencl/share/licenses/ocl-icd-libopencl1-amdgpu-pro/LICENSE
+cp -r files/etc/OpenCL/vendors/* %{buildroot}/etc/OpenCL/vendors/
+cp -r files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opencl/%{_lib}/
+cp -r files/usr/share/doc/opencl-legacy-amdgpu-pro-icd/copyright %{buildroot}/opt/amdgpu-pro/opencl/share/licenses/opencl-legacy-amdgpu-pro-icd/LICENSE
+cp -r files/usr/share/doc/ocl-icd-libopencl1-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opencl/share/licenses/ocl-icd-libopencl1-amdgpu-pro/LICENSE
 #
 mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
 ln -s /opt/amdgpu-pro/opencl/share/licenses/opencl-legacy-amdgpu-pro-icd %{buildroot}/opt/amdgpu-pro/share/licenses/opencl-legacy-amdgpu-pro-icd

--- a/x86_64/amdocl-legacy/amdocl-legacy.spec
+++ b/x86_64/amdocl-legacy/amdocl-legacy.spec
@@ -33,13 +33,13 @@ Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/ocl-ic
  
 
 Provides:      amdocl-legacy = %{major}-%{release}
-Provides:      amdocl-legacy(x86-64) = %{major}-%{release}
+Provides:      amdocl-legacy(x86_64) = %{major}-%{release}
 Provides:      config(opencl-legacy-amdgpu-pro-icd) = %{major}-%{minor}~%{ubuntu}
 Provides:      libopencl-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
 Provides:      ocl-icd-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
-Provides:      ocl-icd-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      ocl-icd-amdgpu-pro(x86_64) = %{major}-%{minor}~%{ubuntu}
 Provides:      opencl-legacy-amdgpu-pro-icd = %{major}-%{minor}~%{ubuntu}
-Provides:      opencl-legacy-amdgpu-pro-icd(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      opencl-legacy-amdgpu-pro-icd(x86_64) = %{major}-%{minor}~%{ubuntu}
 Provides:      opencl-orca-amdgpu-pro-icd  
 
 BuildRequires: wget 

--- a/x86_64/amdocl-legacy/amdocl-legacy.spec
+++ b/x86_64/amdocl-legacy/amdocl-legacy.spec
@@ -9,149 +9,89 @@
 %global amdvlk 2022.Q3.3
 #
 %global drm 2.4.110.50203
-%global drm-common 2.4.110.50203
+%global drm-common 1.0.0.50203
 # Distro info
 %global fedora fc36
 %global ubuntu 22.04
 
 
 Name:          amdocl-legacy
-Version:       %{amdpro}
-Release:       3.%{fedora}
-License:       AMD GPU PRO EULA 
+Version:  	   %{repo}
+Release:       4%{?dist}
+License:       AMDGPU PRO  EULA NON-REDISTRIBUTABLE
 Group:         System Environment/Libraries
 Summary:       AMD OpenCL ICD Loaders
 
-
 URL:           http://repo.radeon.com/amdgpu
+
+%undefine _disable_source_fetch
+Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opencl-legacy-amdgpu-pro/opencl-legacy-amdgpu-pro-icd_%{major}-%{minor}~%{ubuntu}_amd64.deb
+Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/ocl-icd-amdgpu-pro/ocl-icd-libopencl1-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_amd64.deb
+
+ 
+
+Provides:      amdocl-legacy = %{major}-%{release}
+Provides:      amdocl-legacy(x86-64) = %{major}-%{release}
+Provides:      config(opencl-legacy-amdgpu-pro-icd) = 0:%{major}-%{minor}~%{ubuntu}
+Provides:      libopencl-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      ocl-icd-amdgpu-pro = 0:%{major}-%{minor}~%{ubuntu}
+Provides:      ocl-icd-amdgpu-pro(x86-64) = 0:%{major}-%{minor}~%{ubuntu}
+Provides:      opencl-legacy-amdgpu-pro-icd = 0:%{major}-%{minor}~%{ubuntu}
+Provides:      opencl-legacy-amdgpu-pro-icd(x86-64) = 0:%{major}-%{minor}~%{ubuntu}
+Provides:      opencl-orca-amdgpu-pro-icd  
 
 BuildRequires: wget 
 BuildRequires: cpio
 
-Requires:      libdrm-pro  
+Requires(post): /sbin/ldconfig  
+Requires(postun): /sbin/ldconfig  
 
-Provides:      amdocl-legacy = %{major}-3.%{fedora}
-Provides:      amdocl-legacy(x86-64) = %{major}-3.%{fedora}
-Provides:      config(opencl-legacy-amdgpu-pro-icd) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libOpenCL.so.1()(64bit)  
-Provides:      libOpenCL.so.1()(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_1.0)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_1.0)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_1.1)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_1.1)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_1.2)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_1.2)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_2.0)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_2.0)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_2.1)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_2.1)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_2.2)(64bit)  
-Provides:      libOpenCL.so.1(OPENCL_2.2)(64bit)  
-Provides:      libamdocl-orca64.so()(64bit)  
-Provides:      libamdocl-orca64.so()(64bit)  
-Provides:      libamdocl-orca64.so(ACL_0.8)(64bit)  
-Provides:      libamdocl-orca64.so(ACL_0.8)(64bit)  
-Provides:      libamdocl-orca64.so(OPENCL_1.0)(64bit)  
-Provides:      libamdocl-orca64.so(OPENCL_1.0)(64bit)  
-Provides:      libamdocl-orca64.so(OPENCL_1.1)(64bit)  
-Provides:      libamdocl-orca64.so(OPENCL_1.1)(64bit)  
-Provides:      libamdocl-orca64.so(OPENCL_1.2)(64bit)  
-Provides:      libamdocl-orca64.so(OPENCL_1.2)(64bit)  
-Provides:      libamdocl-orca64.so(OPENCL_2.0)(64bit)  
-Provides:      libamdocl-orca64.so(OPENCL_2.0)(64bit)  
-Provides:      libamdocl-orca64.so(OPENCL_2.1)(64bit)  
-Provides:      libamdocl-orca64.so(OPENCL_2.1)(64bit)  
-Provides:      libopencl-amdgpu-pro = %{major}-%{minor}.el%{rhel_minor}
-Provides:      ocl-icd-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      ocl-icd-amdgpu-pro(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      opencl-legacy-amdgpu-pro-icd = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      opencl-legacy-amdgpu-pro-icd(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      opencl-orca-amdgpu-pro-icd  
-Requires(post): /sbin/ldconfig  
-Requires(post): /sbin/ldconfig  
-Requires(postun): /sbin/ldconfig  
-Requires(postun): /sbin/ldconfig  
+Requires:      libdrm-pro 
 
 Recommends: amdgpu-opencl-switcher
-
-%build
-
-echo "pulling required packages off repo.radeon.com"
-
-mkdir -p %{buildroot}/rpms
-
-cd %{buildroot}/rpms
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}"/rhel/"%{rhel_major}"/proprietary/x86_64/opencl-legacy-amdgpu-pro-icd-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}"/rhel/"%{rhel_major}"/proprietary/x86_64/ocl-icd-amdgpu-pro-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm
-
-###
-
-echo "extracting packages"
-
-mkdir -p %{buildroot}/rpms/extract
-
-cd %{buildroot}/rpms/extract
-
-rpm2cpio ../opencl-legacy-amdgpu-pro-icd-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm | cpio -idmv
-
-rpm2cpio ../ocl-icd-amdgpu-pro-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm | cpio -idmv
-
-###
-
-#
-
-echo "restructuring package directories  "
-
-cd  %{buildroot}/rpms/extract
-
-mkdir -p ./opt/amdgpu-pro/OpenCL
-
-mv ./opt/amdgpu-pro/lib64 ./opt/amdgpu-pro/OpenCL/
-
-# 
-
-#echo 'patching libs to use official libdrm'
-
-#sed -i "s|libdrm|libdro|g" ./opt/amdgpu-pro/OpenCL/lib64/*.so
-
-# 
-
-echo "adding *Disabled* library path"
-
-mkdir -p ./etc
-
-mkdir -p ./etc/ld.so.conf.d
-
-touch ./etc/ld.so.conf.d/amdocl-legacy-x86_64.conf
-
-echo "#/opt/amdgpu-pro/OpenCL/lib64" > ./etc/ld.so.conf.d/amdocl-legacy-x86_64.conf
-
-
-cd %{buildroot}/rpms/extract
-
-mv ./opt %{buildroot}/
-mv ./usr %{buildroot}/
-mv ./etc %{buildroot}/
-rm -r %{buildroot}/usr/lib/.build-id || echo 'no build-ids :)'
 
 %description
 OpenCL (Open Computing Language) is a multivendor open standard for
 general-purpose parallel programming of heterogeneous systems that include
 CPUs, GPUs and other processors. + The ICD Loader library provided by AMD.
 
+%prep
+mkdir -p files
+
+ar x --output . %{SOURCE0}
+tar -xJC files -f data.tar.xz
+
+ar x --output . %{SOURCE1}
+tar -xJC files -f data.tar.xz
+
+%install
+mkdir -p %{buildroot}/opt/amdgpu-pro/opencl/%{_lib}
+mkdir -p %{buildroot}/etc/OpenCL/vendors/
+mkdir -p %{buildroot}/opt/amdgpu-pro/opencl/share/licenses/opencl-legacy-amdgpu-pro-icd
+mkdir -p %{buildroot}/opt/amdgpu-pro/opencl/share/licenses/ocl-icd-libopencl1-amdgpu-pro
+#
+install -p -m755 files/etc/OpenCL/vendors/* %{buildroot}/etc/OpenCL/vendors/
+install -p -m755 files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opencl/%{_lib}/
+install -p -m755 files/usr/share/doc/opencl-legacy-amdgpu-pro-icd/copyright %{buildroot}/opt/amdgpu-pro/opencl/share/licenses/opencl-legacy-amdgpu-pro-icd/LICENSE
+install -p -m755 files/usr/share/doc/ocl-icd-libopencl1-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opencl/share/licenses/ocl-icd-libopencl1-amdgpu-pro/LICENSE
+#
+mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
+ln -s /opt/amdgpu-pro/opencl/share/licenses/opencl-legacy-amdgpu-pro-icd %{buildroot}/opt/amdgpu-pro/share/licenses/opencl-legacy-amdgpu-pro-icd
+ln -s /opt/amdgpu-pro/opencl/share/licenses/ocl-icd-libopencl1-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/ocl-icd-libopencl1-amdgpu-pro
+#
+echo "adding *Disabled* library path"
+mkdir -p %{buildroot}/etc/ld.so.conf.d
+touch %{buildroot}/etc/ld.so.conf.d/amdocl-legacy-%{_arch}.conf
+echo "#/opt/amdgpu-pro/opencl/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdocl-legacy-%{_arch}.conf
+
 %files
 "/etc/OpenCL/vendors/amdocl-orca64.icd"
-"/etc/ld.so.conf.d/amdocl-legacy-x86_64.conf"
-"/opt/amdgpu-pro/OpenCL/lib64/libOpenCL.so.1"
-"/opt/amdgpu-pro/OpenCL/lib64/libOpenCL.so.1.2"
-"/opt/amdgpu-pro/OpenCL/lib64/libamdocl-orca64.so"
-"/opt/amdgpu-pro/share/licenses/ocl-icd-amdgpu-pro/AMDGPUPROEULA"
-"/opt/amdgpu-pro/share/licenses/opencl-legacy-amdgpu-pro-icd/AMDGPUPROEULA"
-%exclude "/rpms"
-
-
+"/etc/ld.so.conf.d/amdocl-legacy-%{_arch}.conf"
+"/opt/amdgpu-pro/opencl/%{_lib}/libOpenCL*"
+"/opt/amdgpu-pro/opencl/%{_lib}/libamdocl-orca*"
+"/opt/amdgpu-pro/opencl/share/licenses/opencl-legacy-amdgpu-pro-icd/LICENSE"
+"/opt/amdgpu-pro/opencl/share/licenses/ocl-icd-libopencl1-amdgpu-pro/LICENSE"
+"/opt/amdgpu-pro/share/*"
 
 %post
 /sbin/ldconfig

--- a/x86_64/amdocl-legacy/amdocl-legacy.spec
+++ b/x86_64/amdocl-legacy/amdocl-legacy.spec
@@ -32,12 +32,12 @@ Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/ocl-ic
 
 Provides:      amdocl-legacy = %{major}-%{release}
 Provides:      amdocl-legacy(x86-64) = %{major}-%{release}
-Provides:      config(opencl-legacy-amdgpu-pro-icd) = 0:%{major}-%{minor}~%{ubuntu}
+Provides:      config(opencl-legacy-amdgpu-pro-icd) = %{major}-%{minor}~%{ubuntu}
 Provides:      libopencl-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
-Provides:      ocl-icd-amdgpu-pro = 0:%{major}-%{minor}~%{ubuntu}
-Provides:      ocl-icd-amdgpu-pro(x86-64) = 0:%{major}-%{minor}~%{ubuntu}
-Provides:      opencl-legacy-amdgpu-pro-icd = 0:%{major}-%{minor}~%{ubuntu}
-Provides:      opencl-legacy-amdgpu-pro-icd(x86-64) = 0:%{major}-%{minor}~%{ubuntu}
+Provides:      ocl-icd-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      ocl-icd-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      opencl-legacy-amdgpu-pro-icd = %{major}-%{minor}~%{ubuntu}
+Provides:      opencl-legacy-amdgpu-pro-icd(x86-64) = %{major}-%{minor}~%{ubuntu}
 Provides:      opencl-orca-amdgpu-pro-icd  
 
 BuildRequires: wget 

--- a/x86_64/amdocl-legacy/amdocl-legacy.spec
+++ b/x86_64/amdocl-legacy/amdocl-legacy.spec
@@ -61,10 +61,10 @@ CPUs, GPUs and other processors. + The ICD Loader library provided by AMD.
 mkdir -p files
 
 ar x --output . %{SOURCE0}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE1}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 %install
 mkdir -p %{buildroot}/opt/amdgpu-pro/opencl/%{_lib}

--- a/x86_64/amdocl-legacy/amdocl-legacy.spec
+++ b/x86_64/amdocl-legacy/amdocl-legacy.spec
@@ -1,14 +1,19 @@
-%undefine _auto_set_build_flags
-%global amdpro 22.20.3
+# global info
+%global repo 22.20.3
 %global major 22.20
 %global minor 1462318
+# pkg info
 %global amf 1.4.26
 %global enc 1.0
-%global rhel_major 9.0
-%global rhel_minor 9
+#
 %global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global drm-common 2.4.110.50203
+# Distro info
 %global fedora fc36
 %global ubuntu 22.04
+
 
 Name:          amdocl-legacy
 Version:       %{amdpro}

--- a/x86_64/amdogl-pro/amdogl-pro.spec
+++ b/x86_64/amdogl-pro/amdogl-pro.spec
@@ -36,27 +36,27 @@ Source6:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/a/apppro
 
 Provides:      libEGL.so.1()(64bit)  
 Provides:      libegl-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
-Provides:      libegl-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      libegl-amdgpu-pro(x86_64) = %{major}-%{minor}~%{ubuntu}
 Provides:      libglapi-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
-Provides:      libglapi-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      libglapi-amdgpu-pro(x86_64) = %{major}-%{minor}~%{ubuntu}
 Provides:      libglapi.so.1()(64bit)  
 Provides:      libGLESv2.so.2()(64bit)  
 Provides:      libgles-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
-Provides:      libgles-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgles-amdgpu-pro(x86_64) = %{major}-%{minor}~%{ubuntu}
 Provides:      config(libgl-amdgpu-pro) = %{major}-%{minor}~%{ubuntu}
 Provides:      libGL.so.1()(64bit)  
 Provides:      libGLX_amd.so.0()(64bit)  
 Provides:      libgl-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
-Provides:      libgl-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro(x86_64) = %{major}-%{minor}~%{ubuntu}
 Provides:      config(libgl-amdgpu-pro-appprofiles) = %{major}-%{minor}~%{ubuntu}
 Provides:      libgl-amdgpu-pro-appprofiles = %{major}-%{minor}~%{ubuntu}
 Provides:      config(libgl-amdgpu-pro-dri) = %{major}-%{minor}~%{ubuntu}
 Provides:      libgl-amdgpu-pro-dri = %{major}-%{minor}~%{ubuntu}
-Provides:      libgl-amdgpu-pro-dri(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-dri(x86_64) = %{major}-%{minor}~%{ubuntu}
 Provides:      libgl-amdgpu-pro-ext = %{major}-%{minor}~%{ubuntu}
-Provides:      libgl-amdgpu-pro-ext(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-ext(x86_64) = %{major}-%{minor}~%{ubuntu}
 Provides:      libgl-amdgpu-pro-glx = %{major}-%{minor}~%{ubuntu}
-Provides:      libgl-amdgpu-pro-glx(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-glx(x86_64) = %{major}-%{minor}~%{ubuntu}
 
 BuildRequires: wget 
 BuildRequires: cpio

--- a/x86_64/amdogl-pro/amdogl-pro.spec
+++ b/x86_64/amdogl-pro/amdogl-pro.spec
@@ -129,19 +129,19 @@ mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libglapi1-amdgpu-pro
 mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgles2-amdgpu-pro
 mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-appprofiles
 #
-install -p -m755 files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
-install -p -m755 files/opt/amdgpu-pro/lib/xorg/modules/extensions/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
-install -p -m755 files/usr/lib/x86_64-linux-gnu/dri/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/dri
-install -p -m755 files/opt/amdgpu/share/drirc.d/10-amdgpu-pro.conf %{buildroot}/opt/amdgpu/share/drirc.d/10-amdgpu-pro.conf.disabled
-install -p -m755 files/etc/amd/*  %{buildroot}/etc/amd
+cp -r files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
+cp -r files/opt/amdgpu-pro/lib/xorg/modules/extensions/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
+cp -r files/usr/lib/x86_64-linux-gnu/dri/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/dri
+cp -r files/opt/amdgpu/share/drirc.d/10-amdgpu-pro.conf %{buildroot}/opt/amdgpu/share/drirc.d/10-amdgpu-pro.conf.disabled
+cp -r files/etc/amd/*  %{buildroot}/etc/amd
 #
-install -p -m755 files/usr/share/doc/libegl1-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libegl1-amdgpu-pro/LICENSE
-install -p -m755 files/usr/share/doc/libgl1-amdgpu-pro-dri/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-dri/LICENSE
-install -p -m755 files/usr/share/doc/libgl1-amdgpu-pro-ext/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-ext/LICENSE
-install -p -m755 files/usr/share/doc/libgl1-amdgpu-pro-glx/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-glx/LICENSE
-install -p -m755 files/usr/share/doc/libglapi1-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libglapi1-amdgpu-pro/LICENSE
-install -p -m755 files/usr/share/doc/libgles2-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgles2-amdgpu-pro/LICENSE
-install -p -m755 files/usr/share/doc/libgl1-amdgpu-pro-appprofiles/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-appprofiles/LICENSE
+cp -r files/usr/share/doc/libegl1-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libegl1-amdgpu-pro/LICENSE
+cp -r files/usr/share/doc/libgl1-amdgpu-pro-dri/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-dri/LICENSE
+cp -r files/usr/share/doc/libgl1-amdgpu-pro-ext/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-ext/LICENSE
+cp -r files/usr/share/doc/libgl1-amdgpu-pro-glx/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-glx/LICENSE
+cp -r files/usr/share/doc/libglapi1-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libglapi1-amdgpu-pro/LICENSE
+cp -r files/usr/share/doc/libgles2-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgles2-amdgpu-pro/LICENSE
+cp -r files/usr/share/doc/libgl1-amdgpu-pro-appprofiles/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-appprofiles/LICENSE
 #
 mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
 ln -s /opt/amdgpu-pro/opengl/share/licenses/libegl1-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/libegl1-amdgpu-pro

--- a/x86_64/amdogl-pro/amdogl-pro.spec
+++ b/x86_64/amdogl-pro/amdogl-pro.spec
@@ -24,7 +24,7 @@ URL:      http://repo.radeon.com/amdgpu
 Summary:       AMD OpenGL
 
 %undefine _disable_source_fetch
-Source0:  http://repo.radeon.com/amdgpu/$amdpro/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libegl1-amdgpu-pro_"$major"-"$minor"~"$ubuntu"_amd64.deb
+Source0:  http://repo.radeon.com/amdgpu/$amdpro/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libegl1-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_amd64.deb
 Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-dri_%{major}-%{minor}~%{ubuntu}_amd64.deb
 Source2:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-ext_%{major}-%{minor}~%{ubuntu}_amd64.deb
 Source3:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-glx_%{major}-%{minor}~%{ubuntu}_amd64.deb

--- a/x86_64/amdogl-pro/amdogl-pro.spec
+++ b/x86_64/amdogl-pro/amdogl-pro.spec
@@ -96,25 +96,25 @@ Amdgpu Pro OpenGL driver
 mkdir -p files
 
 ar x --output . %{SOURCE0}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE1}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE2}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE3}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE4}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE5}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE6}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 %install
 mkdir -p %{buildroot}/etc/amd

--- a/x86_64/amdogl-pro/amdogl-pro.spec
+++ b/x86_64/amdogl-pro/amdogl-pro.spec
@@ -24,7 +24,7 @@ URL:      http://repo.radeon.com/amdgpu
 Summary:       AMD OpenGL
 
 %undefine _disable_source_fetch
-Source0:  http://repo.radeon.com/amdgpu/$amdpro/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libegl1-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_amd64.deb
+Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libegl1-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_amd64.deb
 Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-dri_%{major}-%{minor}~%{ubuntu}_amd64.deb
 Source2:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-ext_%{major}-%{minor}~%{ubuntu}_amd64.deb
 Source3:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-glx_%{major}-%{minor}~%{ubuntu}_amd64.deb

--- a/x86_64/amdogl-pro/amdogl-pro.spec
+++ b/x86_64/amdogl-pro/amdogl-pro.spec
@@ -89,3 +89,93 @@ Recommends: amdgpu-opengl-switcher
 
 %description
 Amdgpu Pro OpenGL driver
+
+%prep
+mkdir -p files
+
+ar x --output . %{SOURCE0}
+tar -xJC files -f data.tar.xz
+
+ar x --output . %{SOURCE1}
+tar -xJC files -f data.tar.xz
+
+ar x --output . %{SOURCE2}
+tar -xJC files -f data.tar.xz
+
+ar x --output . %{SOURCE3}
+tar -xJC files -f data.tar.xz
+
+ar x --output . %{SOURCE4}
+tar -xJC files -f data.tar.xz
+
+ar x --output . %{SOURCE5}
+tar -xJC files -f data.tar.xz
+
+ar x --output . %{SOURCE6}
+tar -xJC files -f data.tar.xz
+
+%install
+mkdir -p %{buildroot}/etc/amd
+mkdir -p %{buildroot}/opt/amdgpu/share/drirc.d
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/dri
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libegl1-amdgpu-pro
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-dri
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-ext
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-glx
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libglapi1-amdgpu-pro
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgles2-amdgpu-pro
+mkdir -p %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-appprofiles
+#
+install -p -m755 files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
+install -p -m755 files/opt/amdgpu-pro/lib/xorg/modules/extensions/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/
+install -p -m755 files/usr/lib/x86_64-linux-gnu/dri/* %{buildroot}/opt/amdgpu-pro/opengl/%{_lib}/dri
+install -p -m755 files/opt/amdgpu/share/drirc.d/10-amdgpu-pro.conf %{buildroot}/opt/amdgpu/share/drirc.d/10-amdgpu-pro.conf.disabled
+install -p -m755 files/etc/amd/*  %{buildroot}/etc/amd
+#
+install -p -m755 files/usr/share/doc/libegl1-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libegl1-amdgpu-pro/LICENSE
+install -p -m755 files/usr/share/doc/libgl1-amdgpu-pro-dri/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-dri/LICENSE
+install -p -m755 files/usr/share/doc/libgl1-amdgpu-pro-ext/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-ext/LICENSE
+install -p -m755 files/usr/share/doc/libgl1-amdgpu-pro-glx/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-glx/LICENSE
+install -p -m755 files/usr/share/doc/libglapi1-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libglapi1-amdgpu-pro/LICENSE
+install -p -m755 files/usr/share/doc/libgles2-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgles2-amdgpu-pro/LICENSE
+install -p -m755 files/usr/share/doc/libgl1-amdgpu-pro-appprofiles/copyright %{buildroot}/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-appprofiles/LICENSE
+#
+mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
+ln -s /opt/amdgpu-pro/opengl/share/licenses/libegl1-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/libegl1-amdgpu-pro
+ln -s /opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-dri %{buildroot}/opt/amdgpu-pro/share/licenses/libgl1-amdgpu-pro-dri
+ln -s /opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-ext %{buildroot}/opt/amdgpu-pro/share/licenses/libgl1-amdgpu-pro-ext
+ln -s /opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-glx %{buildroot}/opt/amdgpu-pro/share/licenses/libgl1-amdgpu-pro-glx
+ln -s /opt/amdgpu-pro/opengl/share/licenses/libglapi1-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/libglapi1-amdgpu-pro
+ln -s /opt/amdgpu-pro/opengl/share/licenses/libgles2-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/libgles2-amdgpu-pro
+ln -s /opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-appprofiles %{buildroot}/opt/amdgpu-pro/share/licenses/libgl1-amdgpu-pro-appprofiles
+#
+echo "adding *Disabled* library path"
+mkdir -p %{buildroot}/etc/ld.so.conf.d
+touch %{buildroot}/etc/ld.so.conf.d/amdogl-pro-%{_arch}.conf
+echo "#/opt/amdgpu-pro/opengl/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdogl-pro-%{_arch}.conf
+
+%files
+"/etc/amd/amdapfxx.blb"
+"/etc/amd/amdrc"
+"/etc/ld.so.conf.d/amdogl-pro-%{_arch}.conf"
+"/opt/amdgpu-pro/opengl/%{_lib}/dri/amdgpu_dri.so"
+"/opt/amdgpu-pro/opengl/%{_lib}/libEGL*"
+"/opt/amdgpu-pro/opengl/%{_lib}/libGL*"
+"/opt/amdgpu-pro/opengl/%{_lib}/libgl*"
+"/opt/amdgpu-pro/opengl/share/licenses/libegl1-amdgpu-pro/LICENSE"
+"/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-appprofiles/LICENSE"
+"/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-dri/LICENSE"
+"/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-ext/LICENSE"
+"/opt/amdgpu-pro/opengl/share/licenses/libgl1-amdgpu-pro-glx/LICENSE"
+"/opt/amdgpu-pro/opengl/share/licenses/libglapi1-amdgpu-pro/LICENSE"
+"/opt/amdgpu-pro/opengl/share/licenses/libgles2-amdgpu-pro/LICENSE"
+"/opt/amdgpu-pro/share/*"
+"/opt/amdgpu/share/drirc.d/10-amdgpu-pro.conf.disabled"
+
+%post
+/sbin/ldconfig
+
+%postun
+/sbin/ldconfig
+

--- a/x86_64/amdogl-pro/amdogl-pro.spec
+++ b/x86_64/amdogl-pro/amdogl-pro.spec
@@ -1,3 +1,5 @@
+%define _build_id_links none
+
 # global info
 %global repo 22.20.3
 %global major 22.20

--- a/x86_64/amdogl-pro/amdogl-pro.spec
+++ b/x86_64/amdogl-pro/amdogl-pro.spec
@@ -9,50 +9,62 @@
 %global amdvlk 2022.Q3.3
 #
 %global drm 2.4.110.50203
-%global drm-common 2.4.110.50203
+%global amdgpu 1.0.0.50203
 # Distro info
 %global fedora fc36
 %global ubuntu 22.04
 
 Name:     amdogl-pro
-Version:       %{amdpro}
-Release:       3.%{fedora}
-License:       AMD GPU PRO EULA 
+Version:  	   %{repo}
+Release:       4%{?dist}
+License:       AMDGPU PRO  EULA NON-REDISTRIBUTABLE
 Group:         System Environment/Libraries
 URL:      http://repo.radeon.com/amdgpu
 
 Summary:       AMD OpenGL
 
+%undefine _disable_source_fetch
+Source0:  http://repo.radeon.com/amdgpu/$amdpro/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libegl1-amdgpu-pro_"$major"-"$minor"~"$ubuntu"_amd64.deb
+Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-dri_%{major}-%{minor}~%{ubuntu}_amd64.deb
+Source2:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-ext_%{major}-%{minor}~%{ubuntu}_amd64.deb
+Source3:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgl1-amdgpu-pro-glx_%{major}-%{minor}~%{ubuntu}_amd64.deb
+Source4:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libglapi1-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_amd64.deb
+Source5:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/o/opengl-amdgpu-pro/libgles2-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_amd64.deb
+Source6:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/a/appprofiles-amdgpu-pro/libgl1-amdgpu-pro-appprofiles_%{major}-%{minor}~%{ubuntu}_all.deb
+
 Provides:      libEGL.so.1()(64bit)  
-Provides:      libegl-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libegl-amdgpu-pro(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libglapi-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libglapi-amdgpu-pro(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
+Provides:      libegl-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      libegl-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      libglapi-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      libglapi-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
 Provides:      libglapi.so.1()(64bit)  
 Provides:      libGLESv2.so.2()(64bit)  
-Provides:      libgles-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgles-amdgpu-pro(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      config(libgl-amdgpu-pro) = 0:%{major}-%{minor}.el%{rhel_minor}
+Provides:      libgles-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      libgles-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      config(libgl-amdgpu-pro) = %{major}-%{minor}~%{ubuntu}
 Provides:      libGL.so.1()(64bit)  
 Provides:      libGLX_amd.so.0()(64bit)  
-Provides:      libgl-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      config(libgl-amdgpu-pro-appprofiles) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-appprofiles = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      config(libgl-amdgpu-pro-dri) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-dri = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-dri(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-ext = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-ext(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-glx = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      libgl-amdgpu-pro-glx(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
+Provides:      libgl-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      config(libgl-amdgpu-pro-appprofiles) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-appprofiles = %{major}-%{minor}~%{ubuntu}
+Provides:      config(libgl-amdgpu-pro-dri) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-dri = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-dri(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-ext = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-ext(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-glx = %{major}-%{minor}~%{ubuntu}
+Provides:      libgl-amdgpu-pro-glx(x86-64) = %{major}-%{minor}~%{ubuntu}
+
+BuildRequires: wget 
+BuildRequires: cpio
 
 Requires:      libEGL.so.1()(64bit)    
 Requires:      libGLESv2.so.2()(64bit) 
-Requires:      config(libgl-amdgpu-pro) = 0:%{major}-%{minor}.el%{rhel_minor}
+Requires:      config(libgl-amdgpu-pro) = %{major}-%{minor}~%{ubuntu}
 Requires:      libGLX_amd.so.0()(64bit)
-Requires:      config(libgl-amdgpu-pro-appprofiles) = 0:%{major}-%{minor}.el%{rhel_minor}
-Requires:      config(libgl-amdgpu-pro-dri) = 0:%{major}-%{minor}.el%{rhel_minor}
+Requires:      config(libgl-amdgpu-pro-appprofiles) = %{major}-%{minor}~%{ubuntu}
+Requires:      config(libgl-amdgpu-pro-dri) = %{major}-%{minor}~%{ubuntu}
 Requires:      libGL.so.1()(64bit)  
 Requires:      libX11-xcb.so.1()(64bit)  
 Requires:      libX11.so.6()(64bit)  
@@ -73,145 +85,7 @@ Requires:      libdrm-pro
 Requires(post): /sbin/ldconfig  
 Requires(postun): /sbin/ldconfig 
 
-BuildRequires: wget 
-BuildRequires: cpio
-
 Recommends: amdgpu-opengl-switcher
-
-%build
-
-echo "pulling required packages off repo.radeon.com"
-
-mkdir -p %{buildroot}/rpms
-
-cd %{buildroot}/rpms
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}/rhel/"%{rhel_major}/proprietary/x86_64/libegl-amdgpu-pro-"%{major}-"%{minor}.el"%{rhel_minor}".x86_64.rpm
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}/rhel/"%{rhel_major}/proprietary/x86_64/libgl-amdgpu-pro-"%{major}-"%{minor}.el"%{rhel_minor}".x86_64.rpm
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}/rhel/"%{rhel_major}/proprietary/x86_64/libgl-amdgpu-pro-appprofiles-"%{major}-"%{minor}.el"%{rhel_minor}".noarch.rpm
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}/rhel/"%{rhel_major}/proprietary/x86_64/libgl-amdgpu-pro-dri-"%{major}-"%{minor}.el"%{rhel_minor}".x86_64.rpm
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}/rhel/"%{rhel_major}/proprietary/x86_64/libgl-amdgpu-pro-ext-"%{major}-"%{minor}.el"%{rhel_minor}".x86_64.rpm
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}/rhel/"%{rhel_major}/proprietary/x86_64/libglapi-amdgpu-pro-"%{major}-"%{minor}.el"%{rhel_minor}".x86_64.rpm
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}/rhel/"%{rhel_major}/proprietary/x86_64/libgles-amdgpu-pro-"%{major}-"%{minor}.el"%{rhel_minor}".x86_64.rpm
-
-###
-
-echo "extracting packages"
-
-mkdir -p %{buildroot}/rpms/extract
-
-cd %{buildroot}/rpms/extract
-
-rpm2cpio ../libegl-amdgpu-pro-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm | cpio -idmv
-
-rpm2cpio ../libgl-amdgpu-pro-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm | cpio -idmv
-
-rpm2cpio ../libgl-amdgpu-pro-appprofiles-"%{major}"-"%{minor}".el"%{rhel_minor}".noarch.rpm | cpio -idmv
-
-rpm2cpio ../libgl-amdgpu-pro-dri-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm | cpio -idmv
-
-rpm2cpio ../libgl-amdgpu-pro-ext-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm  | cpio -idmv
-
-rpm2cpio ../libglapi-amdgpu-pro-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm | cpio -idmv
-
-rpm2cpio ../libgles-amdgpu-pro-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm | cpio -idmv
-
-###
-
-#
-
-echo "restructuring package directories  "
-
-cd  %{buildroot}/rpms/extract
-
-echo "adapting to a mesa friendly environment"
-
-mv ./etc/amd ./etc/amd.bak
-
-rm ./etc/ld.so.conf.d/10-amdgpu-pro-x86_64.conf
-
-mv ./opt/amdgpu/share/drirc.d/10-amdgpu-pro.conf ./opt/amdgpu/share/drirc.d/10-amdgpu-pro.conf.disabled
-
-#
-
-echo "restructuring package directories  "
-
-mkdir -p ./opt/amdgpu-pro/OpenGL
-
-mv ./opt/amdgpu-pro/lib64 ./opt/amdgpu-pro/OpenGL/
-
-mv ./usr/lib64/* ./opt/amdgpu-pro/OpenGL/lib64
-
-rm -r ./usr/lib64
-
-mv ./opt/amdgpu-pro/lib/* ./opt/amdgpu-pro/OpenGL/lib64/
-
-# 
-
-#echo 'patching libs to use official libdrm'
-
-#sed -i "s|libdrm|libdro|g" ./opt/amdgpu-pro/OpenGL/lib64/*.so
-
-# 
-
-
-
-echo "adding *Disabled* library path"
-
-mkdir -p ./etc/ld.so.conf.d
-
-touch ./etc/ld.so.conf.d/amdogl-pro-x86_64.conf
-
-echo "# /opt/amdgpu-pro/OpenGL/lib64" > ./etc/ld.so.conf.d/amdogl-pro-x86_64.conf
-
-
-
-cd %{buildroot}/rpms/extract
-
-mv ./opt %{buildroot}/
-mv ./usr %{buildroot}/
-mv ./etc %{buildroot}/
-rm -r %{buildroot}/usr/lib/.build-id || echo 'no build-ids :)'
 
 %description
 Amdgpu Pro OpenGL driver
-
-%files
-%attr(0644, root, root) "/etc/amd.bak/amdapfxx.blb"
-%attr(0644, root, root) "/etc/amd.bak/amdrc"
-%attr(0644, root, root) "/etc/ld.so.conf.d/amdogl-pro-x86_64.conf"
-%attr(0755, root, root) "/opt/amdgpu-pro/OpenGL/lib64/xorg/modules/extensions/libglx.so"
-%attr(0755, root, root) "/opt/amdgpu-pro/OpenGL/lib64/dri/amdgpu_dri.so"
-%attr(0777, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libEGL.so"
-%attr(0755, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libEGL.so.1"
-%attr(0777, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libGL.so"
-%attr(0777, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libGL.so.1"
-%attr(0755, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libGL.so.1.2"
-%attr(0777, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libGLESv2.so"
-%attr(0755, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libGLESv2.so.2"
-%attr(0777, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libGLX_amd.so"
-%attr(0777, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libGLX_amd.so.0"
-%attr(0755, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libGLX_amd.so.0.0"
-%attr(0777, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libglapi.so"
-%attr(0755, root, root) "/opt/amdgpu-pro/OpenGL/lib64/libglapi.so.1"
-%attr(0644, root, root) "/opt/amdgpu-pro/share/licenses/libegl-amdgpu-pro/AMDGPUPROEULA"
-%attr(0644, root, root) "/opt/amdgpu-pro/share/licenses/libgl-amdgpu-pro-appprofiles/AMDGPUPROEULA"
-%attr(0644, root, root) "/opt/amdgpu-pro/share/licenses/libgl-amdgpu-pro-dri/AMDGPUPROEULA"
-%attr(0644, root, root) "/opt/amdgpu-pro/share/licenses/libgl-amdgpu-pro-ext/AMDGPUPROEULA"
-%attr(0644, root, root) "/opt/amdgpu-pro/share/licenses/libgl-amdgpu-pro/AMDGPUPROEULA"
-%attr(0644, root, root) "/opt/amdgpu-pro/share/licenses/libglapi-amdgpu-pro/AMDGPUPROEULA"
-%attr(0644, root, root) "/opt/amdgpu-pro/share/licenses/libgles-amdgpu-pro/AMDGPUPROEULA"
-%attr(0644, root, root) "/opt/amdgpu/share/drirc.d/10-amdgpu-pro.conf.disabled"
-%exclude "/rpms"
-
-%post
-/sbin/ldconfig
-
-%postun
-/sbin/ldconfig

--- a/x86_64/amdogl-pro/amdogl-pro.spec
+++ b/x86_64/amdogl-pro/amdogl-pro.spec
@@ -1,12 +1,16 @@
-%undefine _auto_set_build_flags
-%global amdpro 22.20.3
+# global info
+%global repo 22.20.3
 %global major 22.20
 %global minor 1462318
+# pkg info
 %global amf 1.4.26
 %global enc 1.0
-%global rhel_major 9.0
-%global rhel_minor 9
+#
 %global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global drm-common 2.4.110.50203
+# Distro info
 %global fedora fc36
 %global ubuntu 22.04
 

--- a/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
+++ b/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
@@ -67,7 +67,7 @@ install -p -m755 files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu
 install -p -m755 files/usr/share/doc/vulkan-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro/LICENSE
 #
 mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
-ln -s /opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/vulkan-amdgpu-pro
+ln -s /opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/vulkan-amdgpu-pro-legacy
 #
 echo "fixing .icds "
 sed -i "s#/opt/amdgpu-pro/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu-pro/vulkan-legacy/%{_lib}/amdvlk64.so#" "%{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/amd_icd64.json"

--- a/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
+++ b/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
@@ -79,7 +79,7 @@ echo "#/opt/amdgpu-pro/vulkan-legacy/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/am
 
 %files
 "/etc/ld.so.conf.d/amdvlk-pro-legacy-%{_arch}.conf"
-"/opt/amdgpu-pro/vulkan-legacy/lib64/amdvlk64.so"
+"/opt/amdgpu-pro/vulkan-legacy/lib64/amdvlk64*"
 "/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/amd_icd64.json"
 "/opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro/LICENSE"
 "/opt/amdgpu-pro/share/*"

--- a/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
+++ b/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
@@ -62,9 +62,9 @@ mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan-legacy/%{_lib}
 mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/
 mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro
 #
-install -p -m755 files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/%{_lib}/
-install -p -m755 files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/
-install -p -m755 files/usr/share/doc/vulkan-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro/LICENSE
+cp -r files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/%{_lib}/
+cp -r files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/
+cp -r files/usr/share/doc/vulkan-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro/LICENSE
 #
 mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
 ln -s /opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/vulkan-amdgpu-pro-legacy

--- a/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
+++ b/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
@@ -1,0 +1,91 @@
+%define _build_id_links none
+
+# global info
+%global repo 21.40.2
+%global major 21.40.2
+%global minor 1350682
+# pkg info
+%global amf 1.4.26
+%global enc 1.0
+#
+%global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global amdgpu 1.0.0.50203
+# Distro info
+%global fedora fc36
+%global ubuntu 20.04
+
+Name:     amdvlk-pro-legacy
+Version:  %{repo}
+Release:  4%{?dist}
+License:       AMDGPU PRO  EULA NON-REDISTRIBUTABLE
+Group:         System Environment/Libraries
+Summary:       AMD Vulkan
+URL:      http://repo.radeon.com/amdgpu
+
+%undefine _disable_source_fetch
+Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/v/vulkan-amdgpu-pro/vulkan-amdgpu-pro_%{major}-%{minor}_amd64.deb
+
+Provides:      config(amdvlk-pro) = %{major}-%{release}
+Provides:      amdvlk-pro = %{major}-%{release}
+Provides:      amdvlk-pro(x86-64) = %{major}-%{release}
+Provides:      config(vulkan-amdgpu-pro) = %{major}-%{minor}~%{ubuntu}
+Provides:      vulkan-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      vulkan-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+
+
+Recommends:	 openssl-libs  
+
+BuildRequires: wget 
+BuildRequires: cpio
+
+Requires(post): /sbin/ldconfig  
+Requires(postun): /sbin/ldconfig 
+
+Requires:      vulkan-loader
+Requires:      libdrm-pro  
+
+Recommends:	 amdgpu-vulkan-switcher
+
+%description
+Amdgpu Pro Vulkan driver
+
+%prep
+mkdir -p files
+
+ar x --output . %{SOURCE0}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+%install
+mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan-legacy/%{_lib}
+mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/
+mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro
+#
+install -p -m755 files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/%{_lib}/
+install -p -m755 files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/
+install -p -m755 files/usr/share/doc/vulkan-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro/LICENSE
+#
+mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
+ln -s /opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/vulkan-amdgpu-pro
+#
+echo "fixing .icds "
+sed -i "s#/opt/amdgpu-pro/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu-pro/vulkan-legacy/%{_lib}/amdvlk64.so#" "%{buildroot}/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/amd_icd64.json"
+#
+echo "adding *Disabled* library path"
+mkdir -p %{buildroot}/etc/ld.so.conf.d
+touch %{buildroot}/etc/ld.so.conf.d/amdvlk-pro-legacy-%{_arch}.conf
+echo "#/opt/amdgpu-pro/vulkan-legacy/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-pro-legacy-%{_arch}.conf
+
+%files
+"/etc/ld.so.conf.d/amdvlk-pro-legacy-%{_arch}.conf"
+"/opt/amdgpu-pro/vulkan-legacy/lib64/amdvlk64.so"
+"/opt/amdgpu-pro/vulkan-legacy/etc/vulkan/icd.d/amd_icd64.json"
+"/opt/amdgpu-pro/vulkan-legacy/share/licenses/vulkan-amdgpu-pro/LICENSE"
+"/opt/amdgpu-pro/share/*"
+
+%post
+/sbin/ldconfig
+
+%postun
+/sbin/ldconfig

--- a/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
+++ b/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
@@ -29,10 +29,10 @@ Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/v/vulkan
 
 Provides:      config(amdvlk-pro) = %{major}-%{release}
 Provides:      amdvlk-pro = %{major}-%{release}
-Provides:      amdvlk-pro(x86-64) = %{major}-%{release}
+Provides:      amdvlk-pro(x86_64) = %{major}-%{release}
 Provides:      config(vulkan-amdgpu-pro) = %{major}-%{minor}~%{ubuntu}
 Provides:      vulkan-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
-Provides:      vulkan-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      vulkan-amdgpu-pro(x86_64) = %{major}-%{minor}~%{ubuntu}
 
 
 Recommends:	 openssl-libs  

--- a/x86_64/amdvlk-pro/amdvlk-pro.spec
+++ b/x86_64/amdvlk-pro/amdvlk-pro.spec
@@ -1,3 +1,5 @@
+%define _build_id_links none
+
 # global info
 %global repo 22.20.3
 %global major 22.20
@@ -9,112 +11,82 @@
 %global amdvlk 2022.Q3.3
 #
 %global drm 2.4.110.50203
-%global drm-common 2.4.110.50203
+%global amdgpu 1.0.0.50203
 # Distro info
 %global fedora fc36
 %global ubuntu 22.04
 
 Name:     amdvlk-pro
-Version:       %{amdpro}
-Release:       3.%{fedora}
-License:       AMD GPU PRO EULA 
+Version:  %{repo}
+Release:  4%{?dist}
+License:       AMDGPU PRO  EULA NON-REDISTRIBUTABLE
 Group:         System Environment/Libraries
 Summary:       AMD Vulkan
 URL:      http://repo.radeon.com/amdgpu
 
-Provides:      config(amdvlk-pro) = %{major}-3.%{fedora}
-Provides:      amdvlk-pro = %{major}-3.%{fedora}
-Provides:      amdvlk-pro(x86-64) = %{major}-3.%{fedora}
-Provides:      config(vulkan-amdgpu-pro) = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      vulkan-amdgpu-pro = 0:%{major}-%{minor}.el%{rhel_minor}
-Provides:      vulkan-amdgpu-pro(x86-64) = 0:%{major}-%{minor}.el%{rhel_minor}
-Requires:      vulkan-loader
+%undefine _disable_source_fetch
+Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/v/vulkan-amdgpu-pro/vulkan-amdgpu-pro_%{major}-%{minor}~%{ubuntu}_amd64.deb
+
+Provides:      config(amdvlk-pro) = %{major}-%{release}
+Provides:      amdvlk-pro = %{major}-%{release}
+Provides:      amdvlk-pro(x86-64) = %{major}-%{release}
+Provides:      config(vulkan-amdgpu-pro) = %{major}-%{minor}~%{ubuntu}
+Provides:      vulkan-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
+Provides:      vulkan-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+
 
 Recommends:	 openssl-libs  
-Recommends:	 amdgpu-vulkan-switcher
-
-Requires:      libdrm-pro  
 
 BuildRequires: wget 
 BuildRequires: cpio
 
-%build
+Requires(post): /sbin/ldconfig  
+Requires(postun): /sbin/ldconfig 
 
-echo "pulling required packages off repo.radeon.com"
+Requires:      vulkan-loader
+Requires:      libdrm-pro  
 
-mkdir -p %{buildroot}/rpms
-
-cd %{buildroot}/rpms
-
-wget http://repo.radeon.com/amdgpu/"%{amdpro}"/rhel/"%{rhel_major}"/proprietary/x86_64/vulkan-amdgpu-pro-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm
-
-###
-
-echo "extracting packages"
-
-mkdir -p %{buildroot}/rpms/extract
-
-cd %{buildroot}/rpms/extract
-
-rpm2cpio ../vulkan-amdgpu-pro-"%{major}"-"%{minor}".el"%{rhel_minor}".x86_64.rpm | cpio -idmv
-
-###
-
-#
-
-echo "restructuring package directories  "
-
-cd  %{buildroot}/rpms/extract
-
-mkdir -p ./opt/amdgpu-pro/vulkan
-
-mv ./opt/amdgpu-pro/lib64 ./opt/amdgpu-pro/vulkan/
-#
-
-echo "fixing .icds "
-
-sed -i "s#/opt/amdgpu-pro/lib64/amdvlk64.so#/opt/amdgpu-pro/vulkan/lib64/amdvlk64.so#" "./opt/amdgpu-pro/etc/vulkan/icd.d/amd_icd64.json"
-
-# 
-
-#echo 'patching libs to use official libdrm'
-
-#sed -i "s|libdrm|libdro|g" ./opt/amdgpu-pro/vulkan/lib64/*.so
-
-
-# 
-
-
-
-echo "adding *Disabled* library path"
-
-mkdir -p ./etc
-
-mkdir -p ./etc/ld.so.conf.d
-
-touch ./etc/ld.so.conf.d/amdvlk-pro-x86_64.conf
-
-echo "# /opt/amdgpu-pro/vulkan/lib64" > ./etc/ld.so.conf.d/amdvlk-pro-x86_64.conf
-
-
-
-
-cd %{buildroot}/rpms/extract
-
-mv opt %{buildroot}/
-mv usr %{buildroot}/
-mv etc %{buildroot}/
-rm -r %{buildroot}/usr/lib/.build-id || echo 'no build-ids :)'
+Recommends:	 amdgpu-vulkan-switcher
 
 %description
 Amdgpu Pro Vulkan driver
 
+%prep
+mkdir -p files
+
+ar x --output . %{SOURCE0}
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
+
+%install
+mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan/%{_lib}
+mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/
+mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan/share/licenses/vulkan-amdgpu-pro
+mkdir -p %{buildroot}/opt/amdgpu-pro/etc/vulkan/icd.d/
+#
+install -p -m755 files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan/%{_lib}/
+install -p -m755 files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/
+install -p -m755 files/usr/share/doc/vulkan-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/vulkan/share/licenses/vulkan-amdgpu-pro/LICENSE
+#
+mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
+ln -s /opt/amdgpu-pro/vulkan/share/licenses/vulkan-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/vulkan-amdgpu-pro
+#
+echo "fixing .icds "
+sed -i "s#/opt/amdgpu-pro/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu-pro/vulkan/%{_lib}/amdvlk64.so#" "%{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/amd_icd64.json"
+#
+ln -s /opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/amd_icd64.json %{buildroot}/opt/amdgpu-pro/etc/vulkan/icd.d/
+#
+echo "adding *Disabled* library path"
+mkdir -p %{buildroot}/etc/ld.so.conf.d
+touch %{buildroot}/etc/ld.so.conf.d/amdvlk-pro-%{_arch}.conf
+echo "#/opt/amdgpu-pro/vulkan/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-pro-%{_arch}.conf
+
 %files
+"/etc/ld.so.conf.d/amdvlk-pro-%{_arch}.conf"
 "/opt/amdgpu-pro/etc/vulkan/icd.d/amd_icd64.json"
-"/opt/amdgpu-pro/share/licenses/vulkan-amdgpu-pro/AMDGPUPROEULA"
 "/opt/amdgpu-pro/vulkan/lib64/amdvlk64.so"
-"/etc/ld.so.conf.d/amdvlk-pro-x86_64.conf"
-%exclude "/rpms"
+"/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/amd_icd64.json"
+"/opt/amdgpu-pro/vulkan/share/licenses/vulkan-amdgpu-pro/LICENSE"
+"/opt/amdgpu-pro/share/*"
 
 %post
 /sbin/ldconfig

--- a/x86_64/amdvlk-pro/amdvlk-pro.spec
+++ b/x86_64/amdvlk-pro/amdvlk-pro.spec
@@ -83,7 +83,7 @@ echo "#/opt/amdgpu-pro/vulkan/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-pr
 %files
 "/etc/ld.so.conf.d/amdvlk-pro-%{_arch}.conf"
 "/opt/amdgpu-pro/etc/vulkan/icd.d/amd_icd64.json"
-"/opt/amdgpu-pro/vulkan/lib64/amdvlk64.so"
+"/opt/amdgpu-pro/vulkan/lib64/amdvlk64*"
 "/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/amd_icd64.json"
 "/opt/amdgpu-pro/vulkan/share/licenses/vulkan-amdgpu-pro/LICENSE"
 "/opt/amdgpu-pro/share/*"

--- a/x86_64/amdvlk-pro/amdvlk-pro.spec
+++ b/x86_64/amdvlk-pro/amdvlk-pro.spec
@@ -29,10 +29,10 @@ Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/proprietary/v/vulkan
 
 Provides:      config(amdvlk-pro) = %{major}-%{release}
 Provides:      amdvlk-pro = %{major}-%{release}
-Provides:      amdvlk-pro(x86-64) = %{major}-%{release}
+Provides:      amdvlk-pro(x86_64) = %{major}-%{release}
 Provides:      config(vulkan-amdgpu-pro) = %{major}-%{minor}~%{ubuntu}
 Provides:      vulkan-amdgpu-pro = %{major}-%{minor}~%{ubuntu}
-Provides:      vulkan-amdgpu-pro(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      vulkan-amdgpu-pro(x86_64) = %{major}-%{minor}~%{ubuntu}
 
 
 Recommends:	 openssl-libs  
@@ -83,7 +83,7 @@ echo "#/opt/amdgpu-pro/vulkan/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-pr
 %files
 "/etc/ld.so.conf.d/amdvlk-pro-%{_arch}.conf"
 "/opt/amdgpu-pro/etc/vulkan/icd.d/amd_icd64.json"
-"/opt/amdgpu-pro/vulkan/lib64/amdvlk64*"
+"/opt/amdgpu-pro/vulkan/%{_lib}/amdvlk64*"
 "/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/amd_icd64.json"
 "/opt/amdgpu-pro/vulkan/share/licenses/vulkan-amdgpu-pro/LICENSE"
 "/opt/amdgpu-pro/share/*"

--- a/x86_64/amdvlk-pro/amdvlk-pro.spec
+++ b/x86_64/amdvlk-pro/amdvlk-pro.spec
@@ -63,9 +63,9 @@ mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/
 mkdir -p %{buildroot}/opt/amdgpu-pro/vulkan/share/licenses/vulkan-amdgpu-pro
 mkdir -p %{buildroot}/opt/amdgpu-pro/etc/vulkan/icd.d/
 #
-install -p -m755 files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan/%{_lib}/
-install -p -m755 files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/
-install -p -m755 files/usr/share/doc/vulkan-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/vulkan/share/licenses/vulkan-amdgpu-pro/LICENSE
+cp -r files/opt/amdgpu-pro/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu-pro/vulkan/%{_lib}/
+cp -r files/opt/amdgpu-pro/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu-pro/vulkan/etc/vulkan/icd.d/
+cp -r files/usr/share/doc/vulkan-amdgpu-pro/copyright %{buildroot}/opt/amdgpu-pro/vulkan/share/licenses/vulkan-amdgpu-pro/LICENSE
 #
 mkdir -p %{buildroot}/opt/amdgpu-pro/share/licenses
 ln -s /opt/amdgpu-pro/vulkan/share/licenses/vulkan-amdgpu-pro %{buildroot}/opt/amdgpu-pro/share/licenses/vulkan-amdgpu-pro

--- a/x86_64/amdvlk-pro/amdvlk-pro.spec
+++ b/x86_64/amdvlk-pro/amdvlk-pro.spec
@@ -1,12 +1,16 @@
-%undefine _auto_set_build_flags
-%global amdpro 22.20.3
+# global info
+%global repo 22.20.3
 %global major 22.20
 %global minor 1462318
+# pkg info
 %global amf 1.4.26
 %global enc 1.0
-%global rhel_major 9.0
-%global rhel_minor 9
+#
 %global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global drm-common 2.4.110.50203
+# Distro info
 %global fedora fc36
 %global ubuntu 22.04
 

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -67,10 +67,10 @@ mkdir -p %{buildroot}/opt/amdgpu/vulkan/share/licenses/amdvlk
 mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
 mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/icd.d
 #
-install -p -m755 files/usr/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu/vulkan/%{_lib}/
-install -p -m755 files/etc/vulkan/implicit_layer.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
-install -p -m755 files/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
-install -p -m755 files/usr/share/doc/amdvlk/LICENSE* %{buildroot}/opt/amdgpu/vulkan/share/licenses/amdvlk/LICENSE
+cp -r files/usr/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu/vulkan/%{_lib}/
+cp -r files/etc/vulkan/implicit_layer.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
+cp -r files/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
+cp -r files/usr/share/doc/amdvlk/LICENSE* %{buildroot}/opt/amdgpu/vulkan/share/licenses/amdvlk/LICENSE
 #
 mkdir -p %{buildroot}/opt/amdgpu/share/licenses
 ln -s /opt/amdgpu/vulkan/share/licenses/amdvlk %{buildroot}/opt/amdgpu/share/licenses/amdvlk

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -33,6 +33,8 @@ Source0 :  http://repo.radeon.com/amdvlk/apt/debian/pool/main/a/amdvlk/amdvlk_%{
 Provides:      amdvlk = %{amdvlk}-%{release}
 Provides:      amdvlk(x86_64) = %{amdvlk}-%{release}
 Provides:      config(amdvlk) = %{amdvlk}-%{release}
+Provides:      vulkan-amdgpu = %{major}-%{minor}~%{ubuntu}
+Provides:      vulkan-amdgpu(x86-64) = %{major}-%{minor}~%{ubuntu}
 
 Recommends:	 openssl-libs  
 
@@ -61,6 +63,8 @@ mkdir -p %{buildroot}/opt/amdgpu/vulkan/%{_lib}
 mkdir -p %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
 mkdir -p %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
 mkdir -p %{buildroot}/opt/amdgpu/vulkan/share/licenses/amdvlk
+mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
+mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/icd.d
 #
 install -p -m755 files/usr/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu/vulkan/%{_lib}/
 install -p -m755 files/etc/vulkan/implicit_layer.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
@@ -74,6 +78,9 @@ echo "fixing .icds "
 sed -i "s#/usr/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk64.so#" "%{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd64.json"
 sed -i "s#/usr/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk64.so#" "%{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd64.json"
 #
+ln -s /opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd64.json %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
+ln -s /opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd64.json %{buildroot}/opt/amdgpu/etc/vulkan/icd.d/
+#
 echo "adding *Disabled* library path"
 mkdir -p %{buildroot}/etc/ld.so.conf.d
 touch %{buildroot}/etc/ld.so.conf.d/amdvlk-%{_arch}.conf
@@ -81,6 +88,8 @@ echo "#/opt/amdgpu/vulkan/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-%{_arc
 
 %files
 "/etc/ld.so.conf.d/amdvlk-%{_arch}.conf"
+"/opt/amdgpu/etc/vulkan/icd.d/amd_icd64.json"
+"/opt/amdgpu/etc/vulkan/implicit_layer.d/amd_icd64.json"
 "/opt/amdgpu/vulkan/lib64/amdvlk64.so"
 "/opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd64.json"
 "/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd64.json"

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -34,7 +34,7 @@ Provides:      amdvlk = %{amdvlk}-%{release}
 Provides:      amdvlk(x86_64) = %{amdvlk}-%{release}
 Provides:      config(amdvlk) = %{amdvlk}-%{release}
 Provides:      vulkan-amdgpu = %{major}-%{minor}~%{ubuntu}
-Provides:      vulkan-amdgpu(x86-64) = %{major}-%{minor}~%{ubuntu}
+Provides:      vulkan-amdgpu(x86_64) = %{major}-%{minor}~%{ubuntu}
 
 Recommends:	 openssl-libs  
 
@@ -48,6 +48,7 @@ Requires:      config(amdvlk) = %{amdvlk}-%{release}
 Requires:      vulkan-loader
 Requires:      libdrm-pro  
 
+Recommends:	 amdgpu-vulkan-switcher 
 
 %description
 AMD Open Source Driver for Vulkan
@@ -90,7 +91,7 @@ echo "#/opt/amdgpu/vulkan/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-%{_arc
 "/etc/ld.so.conf.d/amdvlk-%{_arch}.conf"
 "/opt/amdgpu/etc/vulkan/icd.d/amd_icd64.json"
 "/opt/amdgpu/etc/vulkan/implicit_layer.d/amd_icd64.json"
-"/opt/amdgpu/vulkan/lib64/amdvlk64.so"
+"/opt/amdgpu/vulkan/%{_lib}/amdvlk64.so"
 "/opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd64.json"
 "/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd64.json"
 "/opt/amdgpu/vulkan/share/licenses/amdvlk/LICENSE"

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -1,12 +1,16 @@
-%undefine _auto_set_build_flags
-%global amdpro 22.20.3
+# global info
+%global repo 22.20.3
 %global major 22.20
 %global minor 1462318
+# pkg info
 %global amf 1.4.26
 %global enc 1.0
-%global rhel_major 9.0
-%global rhel_minor 9
+#
 %global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global drm-common 2.4.110.50203
+# Distro info
 %global fedora fc36
 %global ubuntu 22.04
 

--- a/x86_64/libdrm-pro/libdrm-pro.spec
+++ b/x86_64/libdrm-pro/libdrm-pro.spec
@@ -82,20 +82,39 @@ mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1
 mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1
 mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu
 mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-common
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/libdrm
 #
 install -p -m755 files/opt/amdgpu/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu/libdrm/%{_lib}/
 install -p -m755 files/usr/share/doc/libdrm-amdgpu-amdgpu1/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1/LICENSE
 install -p -m755 files/usr/share/doc/libdrm-amdgpu-radeon1/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1/LICENSE
 install -p -m755 files/usr/share/doc/libdrm2-amdgpu/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu/LICENSE
 install -p -m755 files/usr/share/doc/libdrm-amdgpu-common/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-common/LICENSE
+install -p -m755 files/opt/amdgpu/share/libdrm/amdgpu.ids %{buildroot}/opt/amdgpu/libdrm/share/libdrm/amdgpu.ids 
 #
 mkdir -p %{buildroot}/opt/amdgpu/share/licenses
 ln -s /opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1 %{buildroot}/opt/amdgpu/share/licenses/libdrm-amdgpu-amdgpu1
 ln -s /opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1 %{buildroot}/opt/amdgpu/share/licenses/libdrm-amdgpu-radeon1
 ln -s /opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu %{buildroot}/opt/amdgpu/share/licenses/libdrm2-amdgpu
 ln -s /opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-common %{buildroot}/opt/amdgpu/share/licenses/libdrm-amdgpu-common
+ln -s /opt/amdgpu/libdrm/share/libdrm %{buildroot}/opt/amdgpu/share/libdrm
 #
 echo "adding *Disabled* library path"
 mkdir -p %{buildroot}/etc/ld.so.conf.d
 touch %{buildroot}/etc/ld.so.conf.d/libdrm-pro-%{_arch}.conf
 echo "#/opt/amdgpu/libdrm/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/libdrm-pro-%{_arch}.conf
+
+%files
+"/etc/ld.so.conf.d/libdrm-pro-%{_arch}.conf"
+"/opt/amdgpu/libdrm/%{_lib}/*drm*"
+"/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1/LICENSE"
+"/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1/LICENSE"
+"/opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu/LICENSE"
+"/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-common/LICENSE"
+"/opt/amdgpu/libdrm/share/libdrm/amdgpu.ids"
+"/opt/amdgpu/share/*"
+
+%post
+/sbin/ldconfig
+
+%postun
+/sbin/ldconfig

--- a/x86_64/libdrm-pro/libdrm-pro.spec
+++ b/x86_64/libdrm-pro/libdrm-pro.spec
@@ -86,12 +86,12 @@ mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu
 mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-common
 mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/libdrm
 #
-install -p -m755 files/opt/amdgpu/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu/libdrm/%{_lib}/
-install -p -m755 files/usr/share/doc/libdrm-amdgpu-amdgpu1/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1/LICENSE
-install -p -m755 files/usr/share/doc/libdrm-amdgpu-radeon1/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1/LICENSE
-install -p -m755 files/usr/share/doc/libdrm2-amdgpu/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu/LICENSE
-install -p -m755 files/usr/share/doc/libdrm-amdgpu-common/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-common/LICENSE
-install -p -m755 files/opt/amdgpu/share/libdrm/amdgpu.ids %{buildroot}/opt/amdgpu/libdrm/share/libdrm/amdgpu.ids 
+cp -r files/opt/amdgpu/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu/libdrm/%{_lib}/
+cp -r files/usr/share/doc/libdrm-amdgpu-amdgpu1/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1/LICENSE
+cp -r files/usr/share/doc/libdrm-amdgpu-radeon1/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1/LICENSE
+cp -r files/usr/share/doc/libdrm2-amdgpu/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu/LICENSE
+cp -r files/usr/share/doc/libdrm-amdgpu-common/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-common/LICENSE
+cp -r files/opt/amdgpu/share/libdrm/amdgpu.ids %{buildroot}/opt/amdgpu/libdrm/share/libdrm/amdgpu.ids 
 #
 mkdir -p %{buildroot}/opt/amdgpu/share/licenses
 ln -s /opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1 %{buildroot}/opt/amdgpu/share/licenses/libdrm-amdgpu-amdgpu1

--- a/x86_64/libdrm-pro/libdrm-pro.spec
+++ b/x86_64/libdrm-pro/libdrm-pro.spec
@@ -1,3 +1,5 @@
+%define _build_id_links none
+
 # global info
 %global repo 22.20.3
 %global major 22.20
@@ -65,16 +67,16 @@ AMD proprietary libdrm
 mkdir -p files
 
 ar x --output . %{SOURCE0}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE1}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE2}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 ar x --output . %{SOURCE3}
-tar -xJC files -f data.tar.xz
+tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 %install
 mkdir -p %{buildroot}/opt/amdgpu/libdrm/%{_lib}

--- a/x86_64/libdrm-pro/libdrm-pro.spec
+++ b/x86_64/libdrm-pro/libdrm-pro.spec
@@ -9,18 +9,24 @@
 %global amdvlk 2022.Q3.3
 #
 %global drm 2.4.110.50203
-%global drm-common 2.4.110.50203
+%global drm-common 1.0.0.50203
 # Distro info
 %global fedora fc36
 %global ubuntu 22.04
 
 Name:     libdrm-pro
-Version:       %{amdpro}
-Release:       3.%{fedora}
-License:       AMD GPU PRO EULA 
+Version:  %{repo}
+Release:  4%{?dist}
+License:       AMDGPU PRO  EULA NON-REDISTRIBUTABLE
 Group:         System Environment/Libraries
 Summary:       AMD proprietary libdrm
 URL:      http://repo.radeon.com/amdgpu
+
+%undefine _disable_source_fetch
+Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu/libdrm-amdgpu-amdgpu1_%{drm}-%{minor}~%{ubuntu}_amd64.deb
+Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu/libdrm-amdgpu-radeon1_%{drm}-%{minor}~%{ubuntu}_amd64.deb
+Source2:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu/libdrm2-amdgpu_%{drm}-%{minor}~%{ubuntu}_amd64.deb
+Source3:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu-common/libdrm-amdgpu-common_%{drm-common}-%{minor}~%{ubuntu}_amd64.deb
 
 Provides:      libdrm-pro
 Provides:      libdrm-pro(x86_64)
@@ -35,135 +41,61 @@ Provides:      libdrm.so.2()(64bit)
 Provides:      libdrm_amdgpu.so.1()(64bit)
 Provides:      libdrm_radeon.so.1()(64bit)
 
-Requires: 	libdrm
+Provides:      libdrm-amdgpu = %{drm}-%{minor}~%{ubuntu}
+Provides:      libdrm-amdgpu-common = %{drm-common}-%{minor}~%{ubuntu}
+
+Provides:      libdrm-amdgpu-amdgpu1 = %{drm}-%{minor}~%{ubuntu}
+Provides:      libdrm-amdgpu-radeon1 = %{drm}-%{minor}~%{ubuntu}
+Provides:      libdrm2-amdgpu = %{drm}-%{minor}~%{ubuntu}
+
+
 
 BuildRequires: wget 
 BuildRequires: cpio
 
-%build
+Requires(post): /sbin/ldconfig  
+Requires(postun): /sbin/ldconfig 
 
-echo "pulling required packages off repo.radeon.com"
-
-mkdir -p %{buildroot}/debs
-
-cd %{buildroot}/debs
-
-wget -r -nd --no-parent -A 'libdrm-amdgpu-amdgpu1*%{ubuntu}_amd64.deb' https://repo.radeon.com/amdgpu/"%{amdpro}"/ubuntu/pool/main/libd/libdrm-amdgpu/
-
-wget -r -nd --no-parent -A 'libdrm-amdgpu-radeon1*%{ubuntu}_amd64.deb' https://repo.radeon.com/amdgpu/"%{amdpro}"/ubuntu/pool/main/libd/libdrm-amdgpu/
-
-wget -r -nd --no-parent -A 'libdrm2-amdgpu*%{ubuntu}_amd64.deb' https://repo.radeon.com/amdgpu/"%{amdpro}"/ubuntu/pool/main/libd/libdrm-amdgpu/
-
-###
-
-echo "extracting packages"
-
-mkdir -p %{buildroot}/debs/extract
-
-cd %{buildroot}/debs/extract
-
-#
-
-ar -x ../libdrm-amdgpu-amdgpu1*%{ubuntu}_amd64.deb
-
-tar -xf data.tar.*
-
-rm -r *.tar*
-
-rm debian-binary
-
-#
-
-ar -x ../libdrm-amdgpu-radeon1*%{ubuntu}_amd64.deb
-
-tar -xf data.tar.*
-
-rm -r *.tar*
-
-rm debian-binary
-
-#
-
-ar -x ../libdrm2-amdgpu*%{ubuntu}_amd64.deb
-
-tar -xf data.tar.*
-
-rm -r *.tar*
-
-rm debian-binary
-
-###
-
-#
-
-echo "restructuring package directories  "
-
-cd %{buildroot}/debs/extract
-
-mkdir -p ./opt/amdgpu/libdrm/lib64
-
-mv ./opt/amdgpu/lib/x86_64-linux-gnu/libdrm.so.2.4.0 ./opt/amdgpu/libdrm/lib64/
-
-mv ./opt/amdgpu/lib/x86_64-linux-gnu/libdrm_amdgpu.so.1.0.0 ./opt/amdgpu/libdrm/lib64/
-
-mv ./opt/amdgpu/lib/x86_64-linux-gnu/libdrm_radeon.so.1.0.1 ./opt/amdgpu/libdrm/lib64/
-
-#
-
-ln -s /opt/amdgpu/libdrm/lib64/libdrm.so.2.4.0 ./opt/amdgpu/libdrm/lib64/libdrm.so.2
-
-ln -s /opt/amdgpu/libdrm/lib64/libdrm_amdgpu.so.1.0.0 ./opt/amdgpu/libdrm/lib64/libdrm_amdgpu.so.1
-
-ln -s /opt/amdgpu/libdrm/lib64/libdrm_radeon.so.1.0.1 ./opt/amdgpu/libdrm/lib64/libdrm_radeon.so.1
-
-#
-
-ln -s /opt/amdgpu/libdrm/lib64/libdrm.so.2.4.0 ./opt/amdgpu/libdrm/lib64/libdrm.so
-
-ln -s /opt/amdgpu/libdrm/lib64/libdrm_amdgpu.so.1.0.0 ./opt/amdgpu/libdrm/lib64/libdrm_amdgpu.so
-
-ln -s /opt/amdgpu/libdrm/lib64/libdrm_radeon.so.1.0.1 ./opt/amdgpu/libdrm/lib64/libdrm_radeon.so
-
-#
-
-mkdir -p "./opt/amdgpu/share/licenses/libdrm-amdgpu-pro"
-
-mv ./usr/share/doc/libdrm2-amdgpu/copyright ./opt/amdgpu/share/licenses/libdrm-amdgpu-pro/libdrm2-amdgpu-copyright
-
-mv ./usr/share/doc/libdrm-amdgpu-amdgpu1/copyright ./opt/amdgpu/share/licenses/libdrm-amdgpu-pro/libdrm-amdgpu-amdgpu1-copyright
-
-mv ./usr/share/doc/libdrm-amdgpu-radeon1/copyright ./opt/amdgpu/share/licenses/libdrm-amdgpu-pro/libdrm-amdgpu-radeon1-copyright
-
-# 
-
-rm -r ./usr/share
-
-#
-
-echo "linking ids"
-
-mkdir -p ./opt/amdgpu/share/libdrm
-
-ln -s /usr/share/libdrm/amdgpu.ids ./opt/amdgpu/share/libdrm/amdgpu.ids
-
-
-cd %{buildroot}/debs/extract
-
-mv opt %{buildroot}/
-rm -r %{buildroot}/usr/lib/.build-id || echo 'no build-ids :)'
+Requires: 	libdrm
 
 %description
 AMD proprietary libdrm
 
-%files
-"/opt/amdgpu/share/libdrm/amdgpu.ids"
-"/opt/amdgpu/share/licenses/libdrm-amdgpu-pro/*-copyright"
-"/opt/amdgpu/libdrm/lib64/*.so*"
-%exclude "/debs"
-%exclude "/opt/amdgpu/lib/x86_64-linux-gnu"
+%prep
+mkdir -p files
 
-%post
-/sbin/ldconfig
+ar x --output . %{SOURCE0}
+tar -xJC files -f data.tar.xz
 
-%postun
-/sbin/ldconfig
+ar x --output . %{SOURCE1}
+tar -xJC files -f data.tar.xz
+
+ar x --output . %{SOURCE2}
+tar -xJC files -f data.tar.xz
+
+ar x --output . %{SOURCE3}
+tar -xJC files -f data.tar.xz
+
+%install
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/%{_lib}
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu
+mkdir -p %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-common
+#
+install -p -m755 files/opt/amdgpu/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu/libdrm/%{_lib}/
+install -p -m755 files/usr/share/doc/libdrm-amdgpu-amdgpu1/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1/LICENSE
+install -p -m755 files/usr/share/doc/libdrm-amdgpu-radeon1/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1/LICENSE
+install -p -m755 files/usr/share/doc/libdrm2-amdgpu/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu/LICENSE
+install -p -m755 files/usr/share/doc/libdrm-amdgpu-common/copyright %{buildroot}/opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-common/LICENSE
+#
+mkdir -p %{buildroot}/opt/amdgpu/share/licenses
+ln -s /opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-amdgpu1 %{buildroot}/opt/amdgpu/share/licenses/libdrm-amdgpu-amdgpu1
+ln -s /opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-radeon1 %{buildroot}/opt/amdgpu/share/licenses/libdrm-amdgpu-radeon1
+ln -s /opt/amdgpu/libdrm/share/licenses/libdrm2-amdgpu %{buildroot}/opt/amdgpu/share/licenses/libdrm2-amdgpu
+ln -s /opt/amdgpu/libdrm/share/licenses/libdrm-amdgpu-common %{buildroot}/opt/amdgpu/share/licenses/libdrm-amdgpu-common
+#
+echo "adding *Disabled* library path"
+mkdir -p %{buildroot}/etc/ld.so.conf.d
+touch %{buildroot}/etc/ld.so.conf.d/libdrm-pro-%{_arch}.conf
+echo "#/opt/amdgpu/libdrm/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/libdrm-pro-%{_arch}.conf

--- a/x86_64/libdrm-pro/libdrm-pro.spec
+++ b/x86_64/libdrm-pro/libdrm-pro.spec
@@ -1,12 +1,16 @@
-%undefine _auto_set_build_flags
-%global amdpro 22.20.3
+# global info
+%global repo 22.20.3
 %global major 22.20
 %global minor 1462318
+# pkg info
 %global amf 1.4.26
 %global enc 1.0
-%global rhel_major 9.0
-%global rhel_minor 9
+#
 %global amdvlk 2022.Q3.3
+#
+%global drm 2.4.110.50203
+%global drm-common 2.4.110.50203
+# Distro info
 %global fedora fc36
 %global ubuntu 22.04
 

--- a/x86_64/libdrm-pro/libdrm-pro.spec
+++ b/x86_64/libdrm-pro/libdrm-pro.spec
@@ -9,7 +9,7 @@
 %global amdvlk 2022.Q3.3
 #
 %global drm 2.4.110.50203
-%global drm-common 1.0.0.50203
+%global amdgpu 1.0.0.50203
 # Distro info
 %global fedora fc36
 %global ubuntu 22.04
@@ -26,7 +26,7 @@ URL:      http://repo.radeon.com/amdgpu
 Source0:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu/libdrm-amdgpu-amdgpu1_%{drm}-%{minor}~%{ubuntu}_amd64.deb
 Source1:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu/libdrm-amdgpu-radeon1_%{drm}-%{minor}~%{ubuntu}_amd64.deb
 Source2:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu/libdrm2-amdgpu_%{drm}-%{minor}~%{ubuntu}_amd64.deb
-Source3:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu-common/libdrm-amdgpu-common_%{drm-common}-%{minor}~%{ubuntu}_amd64.deb
+Source3:  http://repo.radeon.com/amdgpu/%{repo}/ubuntu/pool/main/libd/libdrm-amdgpu-common/libdrm-amdgpu-common_%{amdgpu}-%{minor}~%{ubuntu}_all.deb
 
 Provides:      libdrm-pro
 Provides:      libdrm-pro(x86_64)
@@ -42,7 +42,7 @@ Provides:      libdrm_amdgpu.so.1()(64bit)
 Provides:      libdrm_radeon.so.1()(64bit)
 
 Provides:      libdrm-amdgpu = %{drm}-%{minor}~%{ubuntu}
-Provides:      libdrm-amdgpu-common = %{drm-common}-%{minor}~%{ubuntu}
+Provides:      libdrm-amdgpu-common = %{amdgpu}-%{minor}~%{ubuntu}
 
 Provides:      libdrm-amdgpu-amdgpu1 = %{drm}-%{minor}~%{ubuntu}
 Provides:      libdrm-amdgpu-radeon1 = %{drm}-%{minor}~%{ubuntu}


### PR DESCRIPTION
* massively clean up the spec files.
* 20x times faster package building.
* move to ubuntu LTS packages for more up to date packages. 
* fix licensing 
* use official gpu ids
* add amdvlk-pro-legacy (21.40.2) (installable along side amdvlk-pro , and invoked by vk_legacy).