### PR TITLE
Update amdvlk to v2022.Q4.2 and Various Cleanups

### DIFF
--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -8,7 +8,7 @@
 %global amf 1.4.26
 %global enc 1.0
 #
-%global amdvlk 2022.Q4.1
+%global amdvlk 2022.Q4.2
 #
 %global drm 2.4.110.50203
 %global amdgpu 1.0.0.50203

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -1,7 +1,7 @@
 %define _build_id_links none
 
 # global info
-%global amdvlk 2022.Q4.2
+%global amdvlk 2022.Q4.3
 
 
 Name:          amdvlk

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -1,20 +1,7 @@
 %define _build_id_links none
 
 # global info
-%global repo 22.20.3
-%global major 22.20
-%global minor 1462318
-# pkg info
-%global amf 1.4.26
-%global enc 1.0
-#
 %global amdvlk 2022.Q4.2
-#
-%global drm 2.4.110.50203
-%global amdgpu 1.0.0.50203
-# Distro info
-%global fedora fc36
-%global ubuntu 22.04
 
 
 Name:          amdvlk
@@ -28,27 +15,21 @@ URL:           https://github.com/GPUOpen-Drivers/AMDVLK
 Vendor:        Advanced Micro Devices (AMD)
 
 %undefine _disable_source_fetch
-Source0 :  https://github.com/GPUOpen-Drivers/AMDVLK/releases/download/v-%{amdvlk}/amdvlk_%{amdvlk}_i386.deb
+Source0 :      https://github.com/GPUOpen-Drivers/AMDVLK/releases/download/v-%{amdvlk}/amdvlk_%{amdvlk}_i386.deb
 
 Provides:      amdvlk = %{amdvlk}-%{release}
 Provides:      amdvlk(x86_64) = %{amdvlk}-%{release}
-Provides:      config(amdvlk) = %{amdvlk}-%{release}
-Provides:      vulkan-amdgpu = %{major}-%{minor}~%{ubuntu}
-Provides:      vulkan-amdgpu(i386) = %{major}-%{minor}~%{ubuntu}
-
-Recommends:	 openssl-libs  
 
 BuildRequires: wget 
 BuildRequires: cpio
 
-Requires(post): /sbin/ldconfig  
+Requires(post):   /sbin/ldconfig
 Requires(postun): /sbin/ldconfig 
 
-Requires:      config(amdvlk) = %{amdvlk}-%{release}
 Requires:      vulkan-loader
-Requires:      libdrm-pro(i686) 
+Requires:      openssl-libs
 
-Recommends:	 amdgpu-vulkan-switcher(x86_64)
+Recommends:    amdgpu-vulkan-switcher(x86_64)
 
 %description
 AMD Open Source Driver for Vulkan
@@ -61,21 +42,19 @@ tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 %install
 mkdir -p %{buildroot}/opt/amdgpu/vulkan/%{_lib}
-mkdir -p %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
-mkdir -p %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
 mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
 mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/icd.d
+mkdir -p %{buildroot}/opt/amdgpu/share/licenses/
 #
 cp -r files/usr/lib/i386-linux-gnu/* %{buildroot}/opt/amdgpu/vulkan/%{_lib}/
-cp -r files/etc/vulkan/implicit_layer.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
-cp -r files/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
+cp -r files/etc/vulkan/implicit_layer.d/* %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
+cp -r files/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu/etc/vulkan/icd.d/
+rm -v files/usr/share/doc/amdvlk/changelog.Debian.gz
+mv -v files/usr/share/doc/amdvlk/LICENSE.txt %{buildroot}/opt/amdgpu/share/licenses/LICENSE-%{name}_%{_arch}-%{amdvlk}.txt
 #
-echo "fixing .icds "
-sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd32.json"
-sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd32.json"
-#
-ln -s /opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd32.json %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
-ln -s /opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd32.json %{buildroot}/opt/amdgpu/etc/vulkan/icd.d/
+echo "Fixing ICDs"
+sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/amd_icd32.json"
+sed -i "s#/usr/lib/i386-linux-gnu/amdvlk32.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk32.so#" "%{buildroot}/opt/amdgpu/etc/vulkan/icd.d/amd_icd32.json"
 #
 echo "adding *Disabled* library path"
 mkdir -p %{buildroot}/etc/ld.so.conf.d
@@ -84,11 +63,10 @@ echo "#/opt/amdgpu/vulkan/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-%{_arc
 
 %files
 "/etc/ld.so.conf.d/amdvlk-%{_arch}.conf"
+"/opt/amdgpu/vulkan/%{_lib}/amdvlk32.so"
 "/opt/amdgpu/etc/vulkan/icd.d/amd_icd32.json"
 "/opt/amdgpu/etc/vulkan/implicit_layer.d/amd_icd32.json"
-"/opt/amdgpu/vulkan/%{_lib}/amdvlk32.so"
-"/opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd32.json"
-"/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd32.json"
+"/opt/amdgpu/share/licenses/LICENSE-%{name}_%{_arch}-%{amdvlk}.txt"
 
 %post
 /sbin/ldconfig

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -8,7 +8,7 @@
 %global amf 1.4.26
 %global enc 1.0
 #
-%global amdvlk 2022.Q4.1
+%global amdvlk 2022.Q4.2
 #
 %global drm 2.4.110.50203
 %global amdgpu 1.0.0.50203

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -1,7 +1,7 @@
 %define _build_id_links none
 
 # global info
-%global amdvlk 2022.Q4.2
+%global amdvlk 2022.Q4.3
 
 
 Name:          amdvlk

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -1,20 +1,7 @@
 %define _build_id_links none
 
 # global info
-%global repo 22.20.3
-%global major 22.20
-%global minor 1462318
-# pkg info
-%global amf 1.4.26
-%global enc 1.0
-#
 %global amdvlk 2022.Q4.2
-#
-%global drm 2.4.110.50203
-%global amdgpu 1.0.0.50203
-# Distro info
-%global fedora fc36
-%global ubuntu 22.04
 
 
 Name:          amdvlk
@@ -28,27 +15,21 @@ URL:           https://github.com/GPUOpen-Drivers/AMDVLK
 Vendor:        Advanced Micro Devices (AMD)
 
 %undefine _disable_source_fetch
-Source0 :  https://github.com/GPUOpen-Drivers/AMDVLK/releases/download/v-%{amdvlk}/amdvlk_%{amdvlk}_amd64.deb
+Source0 :      https://github.com/GPUOpen-Drivers/AMDVLK/releases/download/v-%{amdvlk}/amdvlk_%{amdvlk}_amd64.deb
 
 Provides:      amdvlk = %{amdvlk}-%{release}
 Provides:      amdvlk(x86_64) = %{amdvlk}-%{release}
-Provides:      config(amdvlk) = %{amdvlk}-%{release}
-Provides:      vulkan-amdgpu = %{major}-%{minor}~%{ubuntu}
-Provides:      vulkan-amdgpu(x86_64) = %{major}-%{minor}~%{ubuntu}
-
-Recommends:	 openssl-libs  
 
 BuildRequires: wget 
 BuildRequires: cpio
 
-Requires(post): /sbin/ldconfig  
+Requires(post):   /sbin/ldconfig
 Requires(postun): /sbin/ldconfig 
 
-Requires:      config(amdvlk) = %{amdvlk}-%{release}
 Requires:      vulkan-loader
-Requires:      libdrm-pro  
+Requires:      openssl-libs
 
-Recommends:	 amdgpu-vulkan-switcher 
+Recommends:    amdgpu-vulkan-switcher
 
 %description
 AMD Open Source Driver for Vulkan
@@ -61,26 +42,19 @@ tar -xJC files -f data.tar.xz || tar -xC files -f data.tar.gz
 
 %install
 mkdir -p %{buildroot}/opt/amdgpu/vulkan/%{_lib}
-mkdir -p %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
-mkdir -p %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
-mkdir -p %{buildroot}/opt/amdgpu/vulkan/share/licenses/amdvlk
 mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
 mkdir -p %{buildroot}/opt/amdgpu/etc/vulkan/icd.d
+mkdir -p %{buildroot}/opt/amdgpu/share/licenses/
 #
 cp -r files/usr/lib/x86_64-linux-gnu/* %{buildroot}/opt/amdgpu/vulkan/%{_lib}/
-cp -r files/etc/vulkan/implicit_layer.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/
-cp -r files/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/
-cp -r files/usr/share/doc/amdvlk/LICENSE* %{buildroot}/opt/amdgpu/vulkan/share/licenses/amdvlk/LICENSE
+cp -r files/etc/vulkan/implicit_layer.d/* %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
+cp -r files/etc/vulkan/icd.d/* %{buildroot}/opt/amdgpu/etc/vulkan/icd.d/
+rm -v files/usr/share/doc/amdvlk/changelog.Debian.gz
+mv -v files/usr/share/doc/amdvlk/LICENSE.txt %{buildroot}/opt/amdgpu/share/licenses/LICENSE-%{name}_%{_arch}-%{amdvlk}.txt
 #
-mkdir -p %{buildroot}/opt/amdgpu/share/licenses
-ln -s /opt/amdgpu/vulkan/share/licenses/amdvlk %{buildroot}/opt/amdgpu/share/licenses/amdvlk
-#
-echo "fixing .icds "
-sed -i "s#/usr/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk64.so#" "%{buildroot}/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd64.json"
-sed -i "s#/usr/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk64.so#" "%{buildroot}/opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd64.json"
-#
-ln -s /opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd64.json %{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/
-ln -s /opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd64.json %{buildroot}/opt/amdgpu/etc/vulkan/icd.d/
+echo "Fixing ICDs"
+sed -i "s#/usr/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk64.so#" "%{buildroot}/opt/amdgpu/etc/vulkan/implicit_layer.d/amd_icd64.json"
+sed -i "s#/usr/lib/x86_64-linux-gnu/amdvlk64.so#/opt/amdgpu/vulkan/%{_lib}/amdvlk64.so#" "%{buildroot}/opt/amdgpu/etc/vulkan/icd.d/amd_icd64.json"
 #
 echo "adding *Disabled* library path"
 mkdir -p %{buildroot}/etc/ld.so.conf.d
@@ -89,13 +63,10 @@ echo "#/opt/amdgpu/vulkan/%{_lib}" > %{buildroot}/etc/ld.so.conf.d/amdvlk-%{_arc
 
 %files
 "/etc/ld.so.conf.d/amdvlk-%{_arch}.conf"
+"/opt/amdgpu/vulkan/%{_lib}/amdvlk64.so"
 "/opt/amdgpu/etc/vulkan/icd.d/amd_icd64.json"
 "/opt/amdgpu/etc/vulkan/implicit_layer.d/amd_icd64.json"
-"/opt/amdgpu/vulkan/%{_lib}/amdvlk64.so"
-"/opt/amdgpu/vulkan/etc/vulkan/icd.d/amd_icd64.json"
-"/opt/amdgpu/vulkan/etc/vulkan/implicit_layer.d/amd_icd64.json"
-"/opt/amdgpu/vulkan/share/licenses/amdvlk/LICENSE"
-"/opt/amdgpu/share/*"
+"/opt/amdgpu/share/licenses/LICENSE-%{name}_%{_arch}-%{amdvlk}.txt"
 
 %post
 /sbin/ldconfig


### PR DESCRIPTION
This PR updates amdvlk stack to v2022.Q4.2 and also fixes up the spec files for both i386 and x86_64 to what are the minimum requirements needed for amdvlk to run. libdrm-pro is not needed for amdvlk, it uses the existing OS's libdrm (amdgpu) library through AMD's Platform Abstraction Layer (PAL) to interface with the kernel.
Additionally, I copied both the license files and renamed them per the pkg being installed.
