### PR TITLE
Prevent package names from having duplicate "fc"

### DIFF
--- a/i686/amdocl-legacy.i686/amdocl-legacy.i686.spec
+++ b/i686/amdocl-legacy.i686/amdocl-legacy.i686.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 

--- a/i686/amdogl-pro.i686/amdogl-pro.i686.spec
+++ b/i686/amdogl-pro.i686/amdogl-pro.i686.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 

--- a/i686/amdvlk-pro-legacy.i686/amdvlk-pro-legacy.i686.spec
+++ b/i686/amdvlk-pro-legacy.i686/amdvlk-pro-legacy.i686.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.110.50203
 %global amdgpu 1.0.0.50203
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 20.04
 
 Name:     amdvlk-pro-legacy

--- a/i686/amdvlk-pro.i686/amdvlk-pro.i686.spec
+++ b/i686/amdvlk-pro.i686/amdvlk-pro.i686.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 

--- a/i686/amdvlk.i686/amdvlk.i686.spec
+++ b/i686/amdvlk.i686/amdvlk.i686.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 

--- a/i686/libdrm-pro.i686/libdrm-pro.i686.spec
+++ b/i686/libdrm-pro.i686/libdrm-pro.i686.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 

--- a/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
+++ b/x86_64/amdamf-pro-runtime/amdamf-pro-runtime.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 

--- a/x86_64/amdocl-legacy/amdocl-legacy.spec
+++ b/x86_64/amdocl-legacy/amdocl-legacy.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 

--- a/x86_64/amdogl-pro/amdogl-pro.spec
+++ b/x86_64/amdogl-pro/amdogl-pro.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 

--- a/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
+++ b/x86_64/amdvlk-pro-legacy/amdvlk-pro-legacy.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.110.50203
 %global amdgpu 1.0.0.50203
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 20.04
 
 Name:     amdvlk-pro-legacy

--- a/x86_64/amdvlk-pro/amdvlk-pro.spec
+++ b/x86_64/amdvlk-pro/amdvlk-pro.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 

--- a/x86_64/amdvlk/amdvlk.spec
+++ b/x86_64/amdvlk/amdvlk.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 

--- a/x86_64/libdrm-pro/libdrm-pro.spec
+++ b/x86_64/libdrm-pro/libdrm-pro.spec
@@ -12,7 +12,7 @@
 %global drm 2.4.113.50401-1518338
 %global amdgpu 1.0.0.50401-1518338
 # Distro info
-%global fedora fc36
+%global fedora 36
 %global ubuntu 22.04
 
 


### PR DESCRIPTION
Packages were being named similarly to `amdocl-legacy-5.4.1-4.fcfc36.x86_64.rpm` with "fcfc36" rather than "fc36"