### PR TITLE
Resolved issue with versions on 5.5.3 firmware - causing 404's

### DIFF
--- a/x86_64/amd-gpu-pro-firmware/amd-gpu-pro-firmware.spec
+++ b/x86_64/amd-gpu-pro-firmware/amd-gpu-pro-firmware.spec
@@ -12,9 +12,9 @@
 %global drm 2.4.114.50503-1620033
 %global amdgpu 1.0.0.50503-1636786
 # firmware info
-%global firmware_rev 6.0.5
-%global firmware_maj 50503
-%global firmware_min 1620033
+%global firmware_rev 6.2.4
+%global firmware_maj 50700
+%global firmware_min 1637781
 %global _firmwarepath	/usr/lib/firmware
 # Distro info
 %global fedora 38


### PR DESCRIPTION
Wrong firmware_rev, firmware_maj, firmware_min for latest Ubuntu 22.04 drivers